### PR TITLE
[CONFLUENCE-32][CONFLUENCE-42][CONFLUENCE-46][CONFLUENCE-63][CONFLUENCE-64][CONFLUENCE-65] Fix various import issues

### DIFF
--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/ConfluenceXHTMLParser.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/ConfluenceXHTMLParser.java
@@ -55,6 +55,10 @@ import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.RichTextBody
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.SpaceTagHandler;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.TableCellTagHandler;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.TableHeadTagHandler;
+import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.TaskIdTagHandler;
+import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.TaskListTagHandler;
+import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.TaskStatusTagHandler;
+import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.TaskTagHandler;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.URLTagHandler;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.UserTagHandler;
 import org.xwiki.rendering.internal.parser.wikimodel.AbstractWikiModelParser;
@@ -177,6 +181,11 @@ public class ConfluenceXHTMLParser extends AbstractWikiModelParser
         handlers.put("pre", new PreformattedTagHandler());
         
         handlers.put("time", new TimeTagHandler());
+        
+        handlers.put("ac:task-list", new TaskListTagHandler());
+        handlers.put("ac:task", new TaskTagHandler());
+        handlers.put("ac:task-id", new TaskIdTagHandler());
+        handlers.put("ac:task-status", new TaskStatusTagHandler());
 
         parser.setExtraHandlers(handlers);
 

--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/ConfluenceXHTMLParser.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/ConfluenceXHTMLParser.java
@@ -41,6 +41,7 @@ import org.xwiki.contrib.confluence.parser.xhtml.ConfluenceXHTMLInputProperties;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.AttachmentTagHandler;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.ConfluenceXHTMLWhitespaceXMLFilter;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.ConfluenceXWikiGeneratorListener;
+import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.TimeTagHandler;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.DefaultMacroParameterTagHandler;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.ImageTagHandler;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.LinkTagHandler;
@@ -174,6 +175,8 @@ public class ConfluenceXHTMLParser extends AbstractWikiModelParser
         handlers.put("td", new TableCellTagHandler());
         
         handlers.put("pre", new PreformattedTagHandler());
+        
+        handlers.put("time", new TimeTagHandler());
 
         parser.setExtraHandlers(handlers);
 

--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/ConfluenceXHTMLParser.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/ConfluenceXHTMLParser.java
@@ -49,6 +49,7 @@ import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.MacroTagHand
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.PageTagHandler;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.PlainTextBodyTagHandler;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.PlainTextLinkBodyTagHandler;
+import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.PreformattedTagHandler;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.RichTextBodyTagHandler;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.SpaceTagHandler;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.TableCellTagHandler;
@@ -171,6 +172,8 @@ public class ConfluenceXHTMLParser extends AbstractWikiModelParser
 
         handlers.put("th", new TableHeadTagHandler());
         handlers.put("td", new TableCellTagHandler());
+        
+        handlers.put("pre", new PreformattedTagHandler());
 
         parser.setExtraHandlers(handlers);
 

--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/AttachmentTagHandler.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/AttachmentTagHandler.java
@@ -84,10 +84,10 @@ public class AttachmentTagHandler extends TagHandler implements ConfluenceTagHan
             attachment.filename = filenameParameter.getValue();
             
             // set attachment filename as macro parameter if the attachment tag is part of a macro
-            Object macro_obj = context.getTagStack().getStackParameter(CONFLUENCE_CONTAINER);
+            Object macroObject = context.getTagStack().getStackParameter(CONFLUENCE_CONTAINER);
             
-            if (macro_obj instanceof ConfluenceMacro) {
-            	ConfluenceMacro macro = (ConfluenceMacro) macro_obj;
+            if (macroObject instanceof ConfluenceMacro) {
+            	ConfluenceMacro macro = (ConfluenceMacro) macroObject;
             	macro.parameters = macro.parameters.setParameter("att--filename", attachment.filename);
             }
         }

--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/AttachmentTagHandler.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/AttachmentTagHandler.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel;
 
+import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.MacroTagHandler.ConfluenceMacro;
 import org.xwiki.rendering.wikimodel.WikiParameter;
 import org.xwiki.rendering.wikimodel.xhtml.handler.TagHandler;
 import org.xwiki.rendering.wikimodel.xhtml.impl.TagContext;
@@ -37,7 +38,7 @@ import org.xwiki.rendering.wikimodel.xhtml.impl.TagContext;
  * @since 9.0
  */
 public class AttachmentTagHandler extends TagHandler implements ConfluenceTagHandler
-{
+{	
     public class ConfluenceAttachment implements UserContainer, PageContainer
     {
         public String filename;
@@ -81,6 +82,14 @@ public class AttachmentTagHandler extends TagHandler implements ConfluenceTagHan
 
         if (filenameParameter != null) {
             attachment.filename = filenameParameter.getValue();
+            
+            // set attachment filename as macro parameter if the attachment tag is part of a macro
+            Object macro_obj = context.getTagStack().getStackParameter(CONFLUENCE_CONTAINER);
+            
+            if (macro_obj instanceof ConfluenceMacro) {
+            	ConfluenceMacro macro = (ConfluenceMacro) macro_obj;
+            	macro.parameters = macro.parameters.setParameter("att--filename", attachment.filename);
+            }
         }
 
         context.getTagStack().pushStackParameter(CONFLUENCE_CONTAINER, attachment);

--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/PreformattedTagHandler.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/PreformattedTagHandler.java
@@ -1,0 +1,57 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel;
+
+import org.xwiki.rendering.wikimodel.xhtml.impl.TagContext;
+
+/**
+ * Handles preformatted text content. Without this macros in preformatted blocks are lost.
+ * <p>
+ * Example:
+ * <p>
+ * {@code
+ * <pre>Preformatted text</pre>
+ * }
+ *
+ * @version $Id$
+ * @since 9.4.5
+ */
+public class PreformattedTagHandler extends AbstractConfluenceTagHandler implements ConfluenceTagHandler
+{
+    /**
+     * Constructor (checkstyle complains that this comment is missing although the other classes don't have it).
+     */
+    public PreformattedTagHandler()
+    {
+        super(true);
+    }
+
+    @Override
+    protected void begin(TagContext context)
+    {
+        setAccumulateContent(true);
+    }
+
+    @Override
+    protected void end(TagContext context)
+    {
+        context.getScannerContext().onVerbatim(context.getContent(), false);
+    }
+}

--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/TaskIdTagHandler.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/TaskIdTagHandler.java
@@ -1,0 +1,38 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel;
+
+/**
+ * Base class for task properties (id, status, body).
+ * 
+ * @version $Id$
+ * @since 9.4.5
+ */
+public class TaskIdTagHandler extends AbstractConfluenceTagHandler
+    implements ConfluenceTagHandler
+{
+    /**
+     * Default constructor.
+     */
+    public TaskIdTagHandler()
+    {
+        super(false);
+    }
+}

--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/TaskIdTagHandler.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/TaskIdTagHandler.java
@@ -20,7 +20,13 @@
 package org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel;
 
 /**
- * Base class for task properties (id, status, body).
+ * Handles task id.
+ * <p>
+ * Example (ending tags written with backslash instead of normal slash because of checkstyle):
+ * <p>
+ * {@code
+ * <ac:task-id>1<\ac:task-id>
+ * }
  * 
  * @version $Id$
  * @since 9.4.5

--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/TaskListTagHandler.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/TaskListTagHandler.java
@@ -1,0 +1,68 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel;
+
+import org.xwiki.rendering.wikimodel.xhtml.impl.TagContext;
+
+/**
+ * Handles task-list tags using a normal list.
+ * <p>
+ * Example (ending tags written with backslash instead of normal slash because of checkstyle):
+ * <p>
+ * {@code
+ * <ac:task-list>
+ * <ac:task>
+ * <ac:task-id>1<\ac:task-id>
+ * <ac:task-status>complete<\ac:task-status>
+ * <ac:task-body>First task<\ac:task-body>
+ * <\ac:task>
+ * <ac:task>
+ * <ac:task-id>2<\ac:task-id>
+ * <ac:task-status>incomplete<\ac:task-status>
+ * <ac:task-body>Second task<\ac:task-body>
+ * <\ac:task>
+ * <\ac:task-list>
+ * }
+ *
+ * @version $Id$
+ * @since 9.4.5
+ */
+public class TaskListTagHandler extends AbstractConfluenceTagHandler implements ConfluenceTagHandler
+{
+    /**
+     * Constructor (checkstyle complains that this comment is missing although the other classes don't have it).
+     */
+    public TaskListTagHandler()
+    {
+        super(false);
+    }
+
+    @Override
+    protected void begin(TagContext context)
+    {
+        context.getScannerContext().beginList();
+    }
+
+    @Override
+    protected void end(TagContext context)
+    {
+        context.getScannerContext().endList();
+    }
+}

--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/TaskStatusTagHandler.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/TaskStatusTagHandler.java
@@ -1,0 +1,59 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel;
+
+import org.xwiki.rendering.wikimodel.xhtml.impl.TagContext;
+
+/**
+ * Base class for task properties (id, status, body).
+ * 
+ * @version $Id$
+ * @since 9.4.5
+ */
+public class TaskStatusTagHandler extends AbstractConfluenceTagHandler
+    implements ConfluenceTagHandler
+{
+    /**
+     * Default constructor.
+     */
+    public TaskStatusTagHandler()
+    {
+        super(true);
+    }
+
+    @Override
+    protected void begin(TagContext context)
+    {
+        setAccumulateContent(true);
+    }
+
+    @Override
+    protected void end(TagContext context)
+    {
+        // write ticked or unticked checkbox depending on status
+        String status = getContent(context);
+        if (status.equals("complete")) {
+            context.getScannerContext().onWord("\u2611");
+        } else {
+            context.getScannerContext().onWord("\u2610");
+        }
+        context.getScannerContext().onSpace(" ");
+    }
+}

--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/TaskStatusTagHandler.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/TaskStatusTagHandler.java
@@ -22,7 +22,13 @@ package org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel;
 import org.xwiki.rendering.wikimodel.xhtml.impl.TagContext;
 
 /**
- * Base class for task properties (id, status, body).
+ * Handles task status.
+ * <p>
+ * Example (ending tags written with backslash instead of normal slash because of checkstyle):
+ * <p>
+ * {@code
+ * <ac:task-status>complete<\ac:task-status>
+ * }
  * 
  * @version $Id$
  * @since 9.4.5

--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/TaskTagHandler.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/TaskTagHandler.java
@@ -36,7 +36,7 @@ import org.xwiki.rendering.wikimodel.xhtml.impl.TagContext;
  * }
  *
  * @version $Id$
- * @since 9.0
+ * @since 9.4.5
  */
 public class TaskTagHandler extends TagHandler implements ConfluenceTagHandler
 {

--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/TaskTagHandler.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/TaskTagHandler.java
@@ -1,0 +1,62 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel;
+
+import org.xwiki.rendering.wikimodel.xhtml.handler.TagHandler;
+import org.xwiki.rendering.wikimodel.xhtml.impl.TagContext;
+
+/**
+ * Handles task list items.
+ * <p>
+ * Example (ending tags written with backslash instead of normal slash because of checkstyle):
+ * <p>
+ * {@code
+ * <ac:task>
+ * <ac:task-id>1<\ac:task-id>
+ * <ac:task-status>complete<\ac:task-status>
+ * <ac:task-body>First task<\ac:task-body>
+ * <\ac:task>
+ * }
+ *
+ * @version $Id$
+ * @since 9.0
+ */
+public class TaskTagHandler extends TagHandler implements ConfluenceTagHandler
+{
+    /**
+     * Constructor.
+     */
+    public TaskTagHandler()
+    {
+        super(false);
+    }
+
+    @Override
+    protected void begin(TagContext context)
+    { 
+        context.getScannerContext().beginListItem("");
+    }
+
+    @Override
+    protected void end(TagContext context)
+    {
+        context.getScannerContext().endListItem();
+    }
+}

--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/TimeTagHandler.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/TimeTagHandler.java
@@ -1,0 +1,53 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel;
+
+import org.xwiki.rendering.wikimodel.xhtml.handler.TagHandler;
+import org.xwiki.rendering.wikimodel.xhtml.impl.TagContext;
+
+/**
+ * Handles time tags.
+ * <p>
+ * Example:
+ * <p>
+ * {@code
+ * <time datetime="2020-01-12" />
+ * }
+ *
+ * @version $Id$
+ * @since 9.4.5
+ */
+public class TimeTagHandler extends TagHandler implements ConfluenceTagHandler
+{
+    /**
+     * Constructor (checkstyle complains that this comment is missing although the other classes don't have it).
+     */
+    public TimeTagHandler()
+    {
+        super(false);
+    }
+
+    @Override
+    protected void begin(TagContext context)
+    {
+        String date = context.getParams().getParameter("datetime").getValue();
+        context.getScannerContext().onWord(date);
+    }
+}

--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/UserTagHandler.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/UserTagHandler.java
@@ -51,5 +51,11 @@ public class UserTagHandler extends TagHandler implements ConfluenceTagHandler
         if (usernameParameter != null && container instanceof UserContainer) {
             ((UserContainer) container).setUser(usernameParameter.getValue());
         }
+        
+        // new user reference format (by key)
+        WikiParameter userkeyParameter = context.getParams().getParameter("ri:userkey");
+        if (userkeyParameter != null && container instanceof UserContainer) {
+            ((UserContainer) container).setUser(userkeyParameter.getValue());
+        }
     }
 }

--- a/confluence-syntax-xhtml/src/test/resources/confluence+xhtml10/specific/macro/macro3.test
+++ b/confluence-syntax-xhtml/src/test/resources/confluence+xhtml10/specific/macro/macro3.test
@@ -1,0 +1,11 @@
+.#-----------------------------------------------------
+.input|confluence+xhtml/1.0
+.# CONFLUENCE-32: If a macro parameter content in Confluence is an attachment, the parameter value of the generated wiki macro call is empty
+.#-----------------------------------------------------
+<ac:structured-macro ac:name="view-file" ac:schema-version="1"><ac:parameter ac:name="name"><ri:attachment ri:filename="some-file.pdf" /></ac:parameter><ac:parameter ac:name="height">250</ac:parameter></ac:structured-macro>
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+onMacroStandalone [view-file] [att--filename=some-file.pdf|name=|height=250]
+endDocument

--- a/confluence-syntax-xhtml/src/test/resources/confluence+xhtml10/specific/task/task1.test
+++ b/confluence-syntax-xhtml/src/test/resources/confluence+xhtml10/specific/task/task1.test
@@ -1,0 +1,45 @@
+.#-----------------------------------------------------
+.input|confluence+xhtml/1.0
+.# Test task support
+.#-----------------------------------------------------
+<ac:task-list>
+    <ac:task>
+        <ac:task-id>1</ac:task-id>
+        <ac:task-status>complete</ac:task-status>
+        <ac:task-body>First task completed on <time datetime="2020-01-01" /></ac:task-body>
+    </ac:task>
+    <ac:task>
+        <ac:task-id>2</ac:task-id>
+        <ac:task-status>incomplete</ac:task-status>
+        <ac:task-body>Second task</ac:task-body>
+    </ac:task>
+</ac:task-list>
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+beginList [BULLETED]
+beginListItem
+onWord [(((9745)))]
+onSpace
+onWord [First]
+onSpace
+onWord [task]
+onSpace
+onWord [completed]
+onSpace
+onWord [on]
+onSpace
+onWord [2020-01-01]
+endListItem
+endList [BULLETED]
+beginList [BULLETED]
+beginListItem
+onWord [(((9744)))]
+onSpace
+onWord [Second]
+onSpace
+onWord [task]
+endListItem
+endList [BULLETED]
+endDocument

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/ConfluenceXMLPackage.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/ConfluenceXMLPackage.java
@@ -188,6 +188,8 @@ public class ConfluenceXMLPackage
 
     public static final String KEY_ATTACHMENT_DTO = "imageDetailsDTO";
     
+    public static final String KEY_LABEL_NAME = "name";
+    
     public static final String KEY_LABELLING_LABEL = "label";
     
     public static final String KEY_LABELLING_CONTENT = "content";
@@ -1254,12 +1256,19 @@ public class ConfluenceXMLPackage
             : getLong(attachmentProperties, ConfluenceXMLPackage.KEY_ATTACHMENT_ORIGINALVERSION, def);
     }
     
-    public String getTagName(PropertiesConfiguration attachmentProperties)
+    public String getTagName(PropertiesConfiguration labellingProperties)
     {
-        Long tagId = attachmentProperties.getLong(ConfluenceXMLPackage.KEY_LABELLING_LABEL, null);
+        Long tagId = labellingProperties.getLong(ConfluenceXMLPackage.KEY_LABELLING_LABEL, null);
+        String tagName = tagId.toString();
+        
+        try {
+			 PropertiesConfiguration labelProperties = getObjectProperties(tagId);
+			 tagName = labelProperties.getString(KEY_LABEL_NAME);
+		} catch (NumberFormatException | ConfigurationException e) {
+			LOGGER.warn("Unable to get tag name, using id instead.");
+		}
 
-     // TODO: Get the proper tag name instead of returning id
-        return tagId.toString();
+        return tagName;
     }
 
     public Long getLong(PropertiesConfiguration properties, String key, Long def)

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/ConfluenceXMLPackage.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/ConfluenceXMLPackage.java
@@ -1173,7 +1173,6 @@ public class ConfluenceXMLPackage
     public String getCommentText(PropertiesConfiguration commentProperties, Long commentId)
     {
     	String commentText = commentId.toString();
-    	// Long commentContentId = Long.valueOf((String) commentProperties.getList("bodyContents").get(0));
         try {
         	// BodyContent objects are stored in page properties under the content id
 			PropertiesConfiguration commentContent = getPageProperties(commentId, false);
@@ -1183,6 +1182,19 @@ public class ConfluenceXMLPackage
 		}
 
         return commentText;
+    }
+    
+    public Integer getCommentBodyType(PropertiesConfiguration commentProperties, Long commentId)
+    {
+    	Integer bodyType = -1;
+        try {
+			PropertiesConfiguration commentContent = getPageProperties(commentId, false);
+			bodyType = commentContent.getInt("bodyType");
+		} catch (ConfigurationException e) {
+			LOGGER.warn("Unable to get comment body type.");
+		}
+
+        return bodyType;
     }
 
     public Long getLong(PropertiesConfiguration properties, String key, Long def)

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/ConfluenceXMLPackage.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/ConfluenceXMLPackage.java
@@ -800,7 +800,7 @@ public class ConfluenceXMLPackage
             || propertyClass.equals("Comment") || propertyClass.equals("ContentProperty")) {
             return readObjectReference(xmlReader);
         } else if (propertyClass.equals("ConfluenceUserImpl")) {
-        	return readImplObjectReference(xmlReader);
+            return readImplObjectReference(xmlReader);
         } else {
             StAXUtils.skipElement(xmlReader);
         }
@@ -1083,7 +1083,7 @@ public class ConfluenceXMLPackage
 
             users = new TreeSet<>();
             for (String userIdString : userFolders) {
-            	users.add(userIdString);
+                users.add(userIdString);
             }
         } else {
             users = Collections.emptyList();
@@ -1281,38 +1281,38 @@ public class ConfluenceXMLPackage
         String tagName = tagId.toString();
         
         try {
-			 PropertiesConfiguration labelProperties = getObjectProperties(tagId);
-			 tagName = labelProperties.getString(ConfluenceXMLPackage.KEY_LABEL_NAME);
-		} catch (NumberFormatException | ConfigurationException e) {
-			LOGGER.warn("Unable to get tag name, using id instead.");
-		}
+             PropertiesConfiguration labelProperties = getObjectProperties(tagId);
+             tagName = labelProperties.getString(ConfluenceXMLPackage.KEY_LABEL_NAME);
+        } catch (NumberFormatException | ConfigurationException e) {
+            LOGGER.warn("Unable to get tag name, using id instead.");
+        }
 
         return tagName;
     }
     
     public String getCommentText(PropertiesConfiguration commentProperties, Long commentId)
     {
-    	String commentText = commentId.toString();
+        String commentText = commentId.toString();
         try {
-        	// BodyContent objects are stored in page properties under the content id
-			PropertiesConfiguration commentContent = getPageProperties(commentId, false);
-			commentText = commentContent.getString("body");
-		} catch (ConfigurationException e) {
-			LOGGER.warn("Unable to get comment text, using id instead.");
-		}
+            // BodyContent objects are stored in page properties under the content id
+            PropertiesConfiguration commentContent = getPageProperties(commentId, false);
+            commentText = commentContent.getString("body");
+        } catch (ConfigurationException e) {
+            LOGGER.warn("Unable to get comment text, using id instead.");
+        }
 
         return commentText;
     }
     
     public Integer getCommentBodyType(PropertiesConfiguration commentProperties, Long commentId)
     {
-    	Integer bodyType = -1;
+        Integer bodyType = -1;
         try {
-			PropertiesConfiguration commentContent = getPageProperties(commentId, false);
-			bodyType = commentContent.getInt("bodyType");
-		} catch (ConfigurationException e) {
-			LOGGER.warn("Unable to get comment body type.");
-		}
+            PropertiesConfiguration commentContent = getPageProperties(commentId, false);
+            bodyType = commentContent.getInt("bodyType");
+        } catch (ConfigurationException e) {
+            LOGGER.warn("Unable to get comment body type.");
+        }
 
         return bodyType;
     }

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/ConfluenceXMLPackage.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/ConfluenceXMLPackage.java
@@ -74,7 +74,7 @@ import com.google.common.base.Strings;
  */
 public class ConfluenceXMLPackage
 {
-	public static final String FILE_ENTITIES = "entities.xml";
+    public static final String FILE_ENTITIES = "entities.xml";
 
     public static final String FILE_DESCRIPTOR = "exportDescriptor.properties";
 
@@ -113,9 +113,9 @@ public class ConfluenceXMLPackage
     public static final String KEY_PAGE_BODY = "body";
 
     public static final String KEY_PAGE_BODY_TYPE = "bodyType";
-    
+
     public static final String KEY_PAGE_LABELLINGS = "labellings";
-    
+
     public static final String KEY_PAGE_COMMENTS = "comments";
 
     /**
@@ -191,9 +191,9 @@ public class ConfluenceXMLPackage
     public static final String KEY_ATTACHMENT_ORIGINALVERSIONID = "originalVersionId";
 
     public static final String KEY_ATTACHMENT_DTO = "imageDetailsDTO";
-    
+
     public static final String KEY_LABEL_NAME = "name";
-    
+
     public static final String KEY_LABELLING_LABEL = "label";
 
     public static final String KEY_GROUP_NAME = "name";

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/ConfluenceXMLPackage.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/ConfluenceXMLPackage.java
@@ -744,7 +744,7 @@ public class ConfluenceXMLPackage
             return readSetProperty(xmlReader);
         } else if (propertyClass.equals("Page") || propertyClass.equals("Space") || propertyClass.equals("BodyContent")
             || propertyClass.equals("Attachment") || propertyClass.equals("SpaceDescription")
-            || propertyClass.equals("Labelling") || propertyClass.equals("SpacePermission")
+            || propertyClass.equals("Labelling") || propertyClass.equals("Label") || propertyClass.equals("SpacePermission")
             || propertyClass.equals("InternalGroup") || propertyClass.equals("InternalUser")
             || propertyClass.equals("Comment") || propertyClass.equals("ContentProperty")) {
             return readObjectReference(xmlReader);

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/ConfluenceXMLPackage.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/ConfluenceXMLPackage.java
@@ -115,6 +115,8 @@ public class ConfluenceXMLPackage
     public static final String KEY_PAGE_BODY_TYPE = "bodyType";
     
     public static final String KEY_PAGE_LABELLINGS = "labellings";
+    
+    public static final String KEY_PAGE_COMMENTS = "comments";
 
     /**
      * Old property to indicate attachment name.
@@ -1166,6 +1168,21 @@ public class ConfluenceXMLPackage
 		}
 
         return tagName;
+    }
+    
+    public String getCommentText(PropertiesConfiguration commentProperties, Long commentId)
+    {
+    	String commentText = commentId.toString();
+    	// Long commentContentId = Long.valueOf((String) commentProperties.getList("bodyContents").get(0));
+        try {
+        	// BodyContent objects are stored in page properties under the content id
+			PropertiesConfiguration commentContent = getPageProperties(commentId, false);
+			commentText = commentContent.getString("body");
+		} catch (ConfigurationException e) {
+			LOGGER.warn("Unable to get comment text, using id instead.");
+		}
+
+        return commentText;
     }
 
     public Long getLong(PropertiesConfiguration properties, String key, Long def)

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/ConfluenceXMLPackage.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/ConfluenceXMLPackage.java
@@ -74,7 +74,7 @@ import com.google.common.base.Strings;
  */
 public class ConfluenceXMLPackage
 {
-    public static final String FILE_ENTITIES = "entities.xml";
+	public static final String FILE_ENTITIES = "entities.xml";
 
     public static final String FILE_DESCRIPTOR = "exportDescriptor.properties";
 
@@ -187,6 +187,8 @@ public class ConfluenceXMLPackage
     public static final String KEY_ATTACHMENT_ORIGINALVERSIONID = "originalVersionId";
 
     public static final String KEY_ATTACHMENT_DTO = "imageDetailsDTO";
+    
+    public static final String KEY_LABELLING_LABELABLE_TYPE = "labelableType";
 
     public static final String KEY_GROUP_NAME = "name";
 
@@ -608,7 +610,7 @@ public class ConfluenceXMLPackage
             
             // check if the labelling connects the label to a page (labelabletype=CONTENT) or an attachment (labelabletype=ATTACHMENT)
             
-            String contentType = properties.getString(KEY_LABELLING_CONTENT, null);
+            String contentType = properties.getString(KEY_LABELLING_LABELABLE_TYPE, null);
             		
             Long contentId = getLabellingContentId(properties);
 

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/input/ConfluenceInputFilterStream.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/input/ConfluenceInputFilterStream.java
@@ -578,7 +578,7 @@ public class ConfluenceInputFilterStream
 	            parentName = this.confluencePackage.getReferenceFromId(pageProperties, ConfluenceXMLPackage.KEY_PAGE_PARENT).getName();
 	        } catch (Exception e) {
 	            if (this.properties.isVerbose()) {
-	                this.logger.error("Failed to parse parent", e);
+	                this.logger.warn("Failed to parse parent", e);
 	            }
 	        }
 	        
@@ -587,7 +587,7 @@ public class ConfluenceInputFilterStream
 	        	try {
 					parentName = this.confluencePackage.getSpaceName(Long.valueOf(pageProperties.getString(ConfluenceXMLPackage.KEY_PAGE_SPACE)));
 				} catch (NumberFormatException | ConfigurationException e) {
-					this.logger.error("Failed to parse space", e);
+					this.logger.warn("Failed to parse space", e);
 				}
 	        }
 	        
@@ -626,14 +626,21 @@ public class ConfluenceInputFilterStream
 	        proxyFilter.beginWikiClassProperty("tags", "com.xpn.xwiki.objects.classes.StaticListClass", tagClassPropertyParameters);
 	        
 	        // property fields
+	        proxyFilter.onWikiClassPropertyField("cache", "0", new FilterEventParameters());
 	        proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
+	        proxyFilter.onWikiClassPropertyField("displayType", "input", new FilterEventParameters());
+	        proxyFilter.onWikiClassPropertyField("freeText", "forbidden", new FilterEventParameters());
+	        proxyFilter.onWikiClassPropertyField("largeStorage", "0", new FilterEventParameters());
+	        proxyFilter.onWikiClassPropertyField("multiSelect", "1", new FilterEventParameters());
 	        proxyFilter.onWikiClassPropertyField("name", "tags", new FilterEventParameters());
 	        proxyFilter.onWikiClassPropertyField("number", "1", new FilterEventParameters());
 	        proxyFilter.onWikiClassPropertyField("prettyName", "Tags", new FilterEventParameters());
+	        proxyFilter.onWikiClassPropertyField("relationalStorage", "1", new FilterEventParameters());
 	        proxyFilter.onWikiClassPropertyField("separator", "|", new FilterEventParameters());
 	        proxyFilter.onWikiClassPropertyField("separators", "|,", new FilterEventParameters());
 	        proxyFilter.onWikiClassPropertyField("size", "30", new FilterEventParameters());
 	        proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
+	        proxyFilter.onWikiClassPropertyField("values", null, new FilterEventParameters());
 	        
 	        proxyFilter.endWikiClassProperty("tags", "com.xpn.xwiki.objects.classes.StaticListClass", tagClassPropertyParameters);
 	        

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/input/ConfluenceInputFilterStream.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/input/ConfluenceInputFilterStream.java
@@ -753,8 +753,18 @@ public class ConfluenceInputFilterStream
             PropertiesConfiguration commentProperties = pageComments.get(commentId);
             // TODO resolve user reference
             String commentCreator = "xwiki:XWiki." + commentProperties.getString("creator");
-            // TODO parse comment content (currently plain HTML)
-            String commentText = this.confluencePackage.getCommentText(commentProperties, commentId);
+      
+            String commentBodyContent = this.confluencePackage.getCommentText(commentProperties, commentId);
+            int commentBodyType = this.confluencePackage.getCommentBodyType(commentProperties, commentId);
+            String commentText = commentBodyContent;
+            if (commentBodyContent != null && this.properties.isConvertToXWiki()) {
+                try {
+                	commentText = convertToXWiki21(commentBodyContent, commentBodyType);
+                } catch (Exception e) {
+                    this.logger.error("Failed to convert content of the comment with id [{}]", commentId, e);
+                }
+            }          
+            
             Date commentDate = null;
 			try {
 				commentDate = this.confluencePackage.getDate(commentProperties, "creationDate");

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/input/ConfluenceInputFilterStream.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/input/ConfluenceInputFilterStream.java
@@ -592,232 +592,7 @@ public class ConfluenceInputFilterStream
         }
 
         for (Long commentId : pageComments.keySet()) {
-        	//readComment(pageProperties, proxyFilter, pageTags);
-        	String objectName = getObjectName(pageProperties);
-        	FilterEventParameters commentParameters = new FilterEventParameters();               
-            
-            // Comment object
-            commentParameters.put(WikiObjectFilter.PARAMETER_NUMBER, commentIndeces.get(commentId));
-            commentParameters.put(WikiObjectFilter.PARAMETER_CLASS_REFERENCE, "XWiki.XWikiComments");        
-            proxyFilter.beginWikiObject(objectName, commentParameters);
-            
-            // Comment class
-            FilterEventParameters commentClassParameters = new FilterEventParameters();
-            proxyFilter.beginWikiClass(commentClassParameters);
-                        
-            FilterEventParameters commentClassPropertyParameters = new FilterEventParameters();
-            
-            // <author> class property
-            proxyFilter.beginWikiClassProperty("author", "com.xpn.xwiki.objects.classes.UsersClass", commentClassPropertyParameters);
-            proxyFilter.onWikiClassPropertyField("cache", "0", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("displayType", "input", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("multiSelect", "0", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("name", "author", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("number", "1", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("picker", "1", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("prettyName", "Author", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("relationalStorage", "0", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("separator", " ", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("size", "30", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
-            proxyFilter.endWikiClassProperty("author", "com.xpn.xwiki.objects.classes.UsersClass", commentClassPropertyParameters);
-            
-            // <comment> class property
-            proxyFilter.beginWikiClassProperty("comment", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
-            proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("editor", null, new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("name", "comment", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("number", "5", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("prettyName", "Comment", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("rows", "5", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("size", "40", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
-            proxyFilter.endWikiClassProperty("comment", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
-            
-            // <date> class property
-            proxyFilter.beginWikiClassProperty("date", "com.xpn.xwiki.objects.classes.DateClass", commentClassPropertyParameters);
-            proxyFilter.onWikiClassPropertyField("dateFormat", "dd/MM/yyyy HH:mm:ss", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("emptyIsToday", "1", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("name", "date", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("number", "2", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("picker", "1", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("prettyName", "Date", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("size", "20", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
-            proxyFilter.endWikiClassProperty("date", "com.xpn.xwiki.objects.classes.DateClass", commentClassPropertyParameters);
-            
-            // <highlight> class property
-            proxyFilter.beginWikiClassProperty("highlight", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
-            proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("name", "highlight", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("number", "3", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("prettyName", "Highlighted Text", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("rows", "2", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("size", "40", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
-            proxyFilter.endWikiClassProperty("highlight", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
-            
-            // <originalSelection> class property
-            proxyFilter.beginWikiClassProperty("originalSelection", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
-            proxyFilter.onWikiClassPropertyField("contenttype", "PureText", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("editor", "PureText", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("name", "originalSelection", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("number", "6", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("prettyName", "Original Selection", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("rows", "5", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("size", "40", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
-            proxyFilter.endWikiClassProperty("originalSelection", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
-            
-            // <replyto> class property
-            proxyFilter.beginWikiClassProperty("replyto", "com.xpn.xwiki.objects.classes.NumberClass", commentClassPropertyParameters);
-            proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("name", "replyto", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("number", "4", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("numberType", "Integer", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("prettyName", "Reply To", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("size", "5", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
-            proxyFilter.endWikiClassProperty("replyto", "com.xpn.xwiki.objects.classes.NumberClass", commentClassPropertyParameters);
-            
-            // <selection> class property
-            proxyFilter.beginWikiClassProperty("selection", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
-            proxyFilter.onWikiClassPropertyField("contenttype", "PureText", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("editor", "PureText", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("name", "selection", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("number", "3", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("prettyName", "Selection", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("rows", "5", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("size", "40", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
-            proxyFilter.endWikiClassProperty("selection", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
-            
-            // <selectionLeftContext> class property
-            proxyFilter.beginWikiClassProperty("selectionLeftContext", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
-            proxyFilter.onWikiClassPropertyField("contenttype", "PureText", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("editor", "PureText", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("name", "selectionLeftContext", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("number", "4", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("prettyName", "Selection Left Context", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("rows", "5", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("size", "40", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
-            proxyFilter.endWikiClassProperty("selectionLeftContext", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
-            
-            // <selectionRightContext> class property
-            proxyFilter.beginWikiClassProperty("selectionRightContext", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
-            proxyFilter.onWikiClassPropertyField("contenttype", "PureText", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("editor", "PureText", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("name", "selectionRightContext", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("number", "5", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("prettyName", "Selection Right Context", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("rows", "5", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("size", "40", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
-            proxyFilter.endWikiClassProperty("selectionRightContext", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
-            
-            // <state> class property
-            proxyFilter.beginWikiClassProperty("state", "com.xpn.xwiki.objects.classes.StringClass", commentClassPropertyParameters);
-            proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("name", "state", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("number", "8", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("prettyName", "State", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("size", "30", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
-            proxyFilter.endWikiClassProperty("state", "com.xpn.xwiki.objects.classes.StringClass", commentClassPropertyParameters);
-            
-            // <target> class property
-            proxyFilter.beginWikiClassProperty("target", "com.xpn.xwiki.objects.classes.PageClass", commentClassPropertyParameters);
-            proxyFilter.onWikiClassPropertyField("cache", "0", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("classname", null, new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("displayType", "input", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("freeText", "discouraged", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("multiSelect", "0", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("name", "target", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("number", "7", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("picker", "1", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("prettyName", "Target", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("relationalStorage", "0", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("separator", " ", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("size", "30", new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("sql", null, new FilterEventParameters());
-            proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
-            proxyFilter.endWikiClassProperty("target", "com.xpn.xwiki.objects.classes.PageClass", commentClassPropertyParameters);
-                     
-            proxyFilter.endWikiClass(commentClassParameters);
-            
-            // object properties
-            PropertiesConfiguration commentProperties = pageComments.get(commentId);
-            
-            // creator
-            String commentCreator;
-            if (commentProperties.containsKey("creatorName")) {
-            	// old creator reference by name
-            	commentCreator = commentProperties.getString("creatorName");
-            } else {
-            	// new creator reference by key
-            	commentCreator = commentProperties.getString("creator");
-            	try {
-					PropertiesConfiguration creatorProperties = this.confluencePackage.getUserProperties(commentCreator);
-					// replace dots in user names with underlines for XWiki compatibility
-					commentCreator = creatorProperties.getString("name").replace(".", "_");
-				} catch (ConfigurationException e) {
-					if (this.properties.isVerbose()) {
-	                    this.logger.warn("Unable to get comment creator name, using id instead.", e);
-	                }
-				}
-            }
-            String commentCreatorReference = "xwiki:XWiki." + commentCreator;
-            
-            // content
-            String commentBodyContent = this.confluencePackage.getCommentText(commentProperties, commentId);
-            int commentBodyType = this.confluencePackage.getCommentBodyType(commentProperties, commentId);
-            String commentText = commentBodyContent;
-            if (commentBodyContent != null && this.properties.isConvertToXWiki()) {
-                try {
-                	commentText = convertToXWiki21(commentBodyContent, commentBodyType);
-                } catch (Exception e) {
-                    this.logger.error("Failed to convert content of the comment with id [{}]", commentId, e);
-                }
-            }          
-            
-            // creation date
-            Date commentDate = null;
-			try {
-				commentDate = this.confluencePackage.getDate(commentProperties, "creationDate");
-			} catch (java.text.ParseException e) {
-				if (this.properties.isVerbose()) {
-                    this.logger.error("Failed to parse date", e);
-                }
-			}
-			
-			// parent (replyto)
-			Long parentIndex = null;
-			if (commentProperties.containsKey("parent")) {
-				Long parentId = commentProperties.getLong("parent");
-				parentIndex = commentIndeces.get(parentId);
-			}
-            
-            proxyFilter.onWikiObjectProperty("author", commentCreatorReference, new FilterEventParameters());
-            proxyFilter.onWikiObjectProperty("comment", commentText, new FilterEventParameters());
-            proxyFilter.onWikiObjectProperty("date", commentDate, new FilterEventParameters());
-            proxyFilter.onWikiObjectProperty("highlight", "", new FilterEventParameters());
-            proxyFilter.onWikiObjectProperty("originalSelection", "", new FilterEventParameters());
-            proxyFilter.onWikiObjectProperty("replyto", parentIndex, new FilterEventParameters());
-            proxyFilter.onWikiObjectProperty("selection", "", new FilterEventParameters());
-            proxyFilter.onWikiObjectProperty("selectionLeftContext", "", new FilterEventParameters());
-            proxyFilter.onWikiObjectProperty("selectionRightContext", "", new FilterEventParameters());
-            proxyFilter.onWikiObjectProperty("state", "", new FilterEventParameters());
-            proxyFilter.onWikiObjectProperty("target", "", new FilterEventParameters());
-            
-            proxyFilter.endWikiObject(objectName, commentParameters); 
+        	readPageComment(pageProperties, proxyFilter, commentId, pageComments, commentIndeces);
         }
 
         // < WikiDocumentRevision
@@ -972,7 +747,8 @@ public class ConfluenceInputFilterStream
     }
     
     private void readPageTags(PropertiesConfiguration pageProperties, ConfluenceFilter proxyFilter,
-    		Map<String, PropertiesConfiguration> pageTags) throws FilterException {
+    		Map<String, PropertiesConfiguration> pageTags) throws FilterException 
+    {
     	FilterEventParameters pageTagsParameters = new FilterEventParameters();     
         String objectName = getObjectName(pageProperties);
         
@@ -1025,7 +801,239 @@ public class ConfluenceInputFilterStream
         proxyFilter.endWikiObject(objectName, pageTagsParameters);
     }
     
-    private String getObjectName(PropertiesConfiguration pageProperties) {
+    private void readPageComment (PropertiesConfiguration pageProperties, ConfluenceFilter proxyFilter, 
+    		Long commentId, Map<Long, PropertiesConfiguration> pageComments, Map<Long, Long> commentIndeces)
+    		throws FilterException
+    {
+    	String objectName = getObjectName(pageProperties);
+    	FilterEventParameters commentParameters = new FilterEventParameters();               
+        
+        // Comment object
+        commentParameters.put(WikiObjectFilter.PARAMETER_NUMBER, commentIndeces.get(commentId));
+        commentParameters.put(WikiObjectFilter.PARAMETER_CLASS_REFERENCE, "XWiki.XWikiComments");        
+        proxyFilter.beginWikiObject(objectName, commentParameters);
+        
+        // Comment class
+        FilterEventParameters commentClassParameters = new FilterEventParameters();
+        proxyFilter.beginWikiClass(commentClassParameters);
+                    
+        FilterEventParameters commentClassPropertyParameters = new FilterEventParameters();
+        
+        // <author> class property
+        proxyFilter.beginWikiClassProperty("author", "com.xpn.xwiki.objects.classes.UsersClass", commentClassPropertyParameters);
+        proxyFilter.onWikiClassPropertyField("cache", "0", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("displayType", "input", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("multiSelect", "0", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("name", "author", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("number", "1", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("picker", "1", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("prettyName", "Author", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("relationalStorage", "0", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("separator", " ", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("size", "30", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
+        proxyFilter.endWikiClassProperty("author", "com.xpn.xwiki.objects.classes.UsersClass", commentClassPropertyParameters);
+        
+        // <comment> class property
+        proxyFilter.beginWikiClassProperty("comment", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
+        proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("editor", null, new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("name", "comment", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("number", "5", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("prettyName", "Comment", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("rows", "5", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("size", "40", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
+        proxyFilter.endWikiClassProperty("comment", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
+        
+        // <date> class property
+        proxyFilter.beginWikiClassProperty("date", "com.xpn.xwiki.objects.classes.DateClass", commentClassPropertyParameters);
+        proxyFilter.onWikiClassPropertyField("dateFormat", "dd/MM/yyyy HH:mm:ss", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("emptyIsToday", "1", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("name", "date", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("number", "2", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("picker", "1", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("prettyName", "Date", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("size", "20", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
+        proxyFilter.endWikiClassProperty("date", "com.xpn.xwiki.objects.classes.DateClass", commentClassPropertyParameters);
+        
+        // <highlight> class property
+        proxyFilter.beginWikiClassProperty("highlight", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
+        proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("name", "highlight", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("number", "3", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("prettyName", "Highlighted Text", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("rows", "2", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("size", "40", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
+        proxyFilter.endWikiClassProperty("highlight", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
+        
+        // <originalSelection> class property
+        proxyFilter.beginWikiClassProperty("originalSelection", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
+        proxyFilter.onWikiClassPropertyField("contenttype", "PureText", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("editor", "PureText", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("name", "originalSelection", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("number", "6", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("prettyName", "Original Selection", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("rows", "5", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("size", "40", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
+        proxyFilter.endWikiClassProperty("originalSelection", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
+        
+        // <replyto> class property
+        proxyFilter.beginWikiClassProperty("replyto", "com.xpn.xwiki.objects.classes.NumberClass", commentClassPropertyParameters);
+        proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("name", "replyto", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("number", "4", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("numberType", "Integer", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("prettyName", "Reply To", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("size", "5", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
+        proxyFilter.endWikiClassProperty("replyto", "com.xpn.xwiki.objects.classes.NumberClass", commentClassPropertyParameters);
+        
+        // <selection> class property
+        proxyFilter.beginWikiClassProperty("selection", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
+        proxyFilter.onWikiClassPropertyField("contenttype", "PureText", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("editor", "PureText", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("name", "selection", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("number", "3", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("prettyName", "Selection", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("rows", "5", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("size", "40", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
+        proxyFilter.endWikiClassProperty("selection", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
+        
+        // <selectionLeftContext> class property
+        proxyFilter.beginWikiClassProperty("selectionLeftContext", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
+        proxyFilter.onWikiClassPropertyField("contenttype", "PureText", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("editor", "PureText", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("name", "selectionLeftContext", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("number", "4", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("prettyName", "Selection Left Context", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("rows", "5", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("size", "40", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
+        proxyFilter.endWikiClassProperty("selectionLeftContext", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
+        
+        // <selectionRightContext> class property
+        proxyFilter.beginWikiClassProperty("selectionRightContext", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
+        proxyFilter.onWikiClassPropertyField("contenttype", "PureText", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("editor", "PureText", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("name", "selectionRightContext", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("number", "5", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("prettyName", "Selection Right Context", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("rows", "5", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("size", "40", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
+        proxyFilter.endWikiClassProperty("selectionRightContext", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
+        
+        // <state> class property
+        proxyFilter.beginWikiClassProperty("state", "com.xpn.xwiki.objects.classes.StringClass", commentClassPropertyParameters);
+        proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("name", "state", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("number", "8", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("prettyName", "State", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("size", "30", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
+        proxyFilter.endWikiClassProperty("state", "com.xpn.xwiki.objects.classes.StringClass", commentClassPropertyParameters);
+        
+        // <target> class property
+        proxyFilter.beginWikiClassProperty("target", "com.xpn.xwiki.objects.classes.PageClass", commentClassPropertyParameters);
+        proxyFilter.onWikiClassPropertyField("cache", "0", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("classname", null, new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("displayType", "input", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("freeText", "discouraged", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("multiSelect", "0", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("name", "target", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("number", "7", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("picker", "1", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("prettyName", "Target", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("relationalStorage", "0", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("separator", " ", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("size", "30", new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("sql", null, new FilterEventParameters());
+        proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
+        proxyFilter.endWikiClassProperty("target", "com.xpn.xwiki.objects.classes.PageClass", commentClassPropertyParameters);
+                 
+        proxyFilter.endWikiClass(commentClassParameters);
+        
+        // object properties
+        PropertiesConfiguration commentProperties = pageComments.get(commentId);
+        
+        // creator
+        String commentCreator;
+        if (commentProperties.containsKey("creatorName")) {
+        	// old creator reference by name
+        	commentCreator = commentProperties.getString("creatorName");
+        } else {
+        	// new creator reference by key
+        	commentCreator = commentProperties.getString("creator");
+        	try {
+				PropertiesConfiguration creatorProperties = this.confluencePackage.getUserProperties(commentCreator);
+				// replace dots in user names with underlines for XWiki compatibility
+				commentCreator = creatorProperties.getString("name").replace(".", "_");
+			} catch (ConfigurationException e) {
+				if (this.properties.isVerbose()) {
+                    this.logger.warn("Unable to get comment creator name, using id instead.", e);
+                }
+			}
+        }
+        String commentCreatorReference = "xwiki:XWiki." + commentCreator;
+        
+        // content
+        String commentBodyContent = this.confluencePackage.getCommentText(commentProperties, commentId);
+        int commentBodyType = this.confluencePackage.getCommentBodyType(commentProperties, commentId);
+        String commentText = commentBodyContent;
+        if (commentBodyContent != null && this.properties.isConvertToXWiki()) {
+            try {
+            	commentText = convertToXWiki21(commentBodyContent, commentBodyType);
+            } catch (Exception e) {
+                this.logger.error("Failed to convert content of the comment with id [{}]", commentId, e);
+            }
+        }          
+        
+        // creation date
+        Date commentDate = null;
+		try {
+			commentDate = this.confluencePackage.getDate(commentProperties, "creationDate");
+		} catch (java.text.ParseException e) {
+			if (this.properties.isVerbose()) {
+                this.logger.error("Failed to parse date", e);
+            }
+		}
+		
+		// parent (replyto)
+		Long parentIndex = null;
+		if (commentProperties.containsKey("parent")) {
+			Long parentId = commentProperties.getLong("parent");
+			parentIndex = commentIndeces.get(parentId);
+		}
+        
+        proxyFilter.onWikiObjectProperty("author", commentCreatorReference, new FilterEventParameters());
+        proxyFilter.onWikiObjectProperty("comment", commentText, new FilterEventParameters());
+        proxyFilter.onWikiObjectProperty("date", commentDate, new FilterEventParameters());
+        proxyFilter.onWikiObjectProperty("highlight", "", new FilterEventParameters());
+        proxyFilter.onWikiObjectProperty("originalSelection", "", new FilterEventParameters());
+        proxyFilter.onWikiObjectProperty("replyto", parentIndex, new FilterEventParameters());
+        proxyFilter.onWikiObjectProperty("selection", "", new FilterEventParameters());
+        proxyFilter.onWikiObjectProperty("selectionLeftContext", "", new FilterEventParameters());
+        proxyFilter.onWikiObjectProperty("selectionRightContext", "", new FilterEventParameters());
+        proxyFilter.onWikiObjectProperty("state", "", new FilterEventParameters());
+        proxyFilter.onWikiObjectProperty("target", "", new FilterEventParameters());
+        
+        proxyFilter.endWikiObject(objectName, commentParameters); 
+    }
+    
+    private String getObjectName(PropertiesConfiguration pageProperties)
+    {
     	// get parent name from reference
         String parentName = "";
         try {

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/input/ConfluenceInputFilterStream.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/input/ConfluenceInputFilterStream.java
@@ -1002,20 +1002,20 @@ public class ConfluenceInputFilterStream
         
         // creation date
         Date commentDate = null;
-		try {
-			commentDate = this.confluencePackage.getDate(commentProperties, "creationDate");
-		} catch (java.text.ParseException e) {
-			if (this.properties.isVerbose()) {
+        try {
+        	commentDate = this.confluencePackage.getDate(commentProperties, "creationDate");
+        } catch (java.text.ParseException e) {
+        	if (this.properties.isVerbose()) {
                 this.logger.error("Failed to parse date", e);
             }
-		}
-		
-		// parent (replyto)
-		Long parentIndex = null;
-		if (commentProperties.containsKey("parent")) {
-			Long parentId = commentProperties.getLong("parent");
-			parentIndex = commentIndeces.get(parentId);
-		}
+        }
+        
+        // parent (replyto)
+        Long parentIndex = null;
+        if (commentProperties.containsKey("parent")) {
+        	Long parentId = commentProperties.getLong("parent");
+        	parentIndex = commentIndeces.get(parentId);
+        }
         
         proxyFilter.onWikiObjectProperty("author", commentCreatorReference, new FilterEventParameters());
         proxyFilter.onWikiObjectProperty("comment", commentText, new FilterEventParameters());

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/input/ConfluenceInputFilterStream.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/input/ConfluenceInputFilterStream.java
@@ -555,10 +555,11 @@ public class ConfluenceInputFilterStream
         
         // Tags
         Map<String, PropertiesConfiguration> pageTags = new LinkedHashMap<>();
-        for (long tagId : this.confluencePackage.getTags(pageId)) {
+        for (Object tagIdStringObject : pageProperties.getList(ConfluenceXMLPackage.KEY_PAGE_LABELLINGS)) {
+        	long tagId = Long.valueOf((String) tagIdStringObject);
             PropertiesConfiguration tagProperties;
             try {
-                tagProperties = this.confluencePackage.getPageTagProperties(pageId, tagId);
+                tagProperties = this.confluencePackage.getObjectProperties(tagId);
             } catch (ConfigurationException e) {
                 throw new FilterException("Failed to get tag properties", e);
             }

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/input/ConfluenceInputFilterStream.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/input/ConfluenceInputFilterStream.java
@@ -565,12 +565,221 @@ public class ConfluenceInputFilterStream
             }
 
             String tagName = this.confluencePackage.getTagName(tagProperties);
-
             pageTags.put(tagName, tagProperties);
         }
 
         if (!pageTags.isEmpty()) {
         	readPageTags(pageProperties, proxyFilter, pageTags);
+        }
+        
+        // Comments
+        Map<Long, PropertiesConfiguration> pageComments = new LinkedHashMap<>();
+        for (Object commentIdStringObject : pageProperties.getList(ConfluenceXMLPackage.KEY_PAGE_COMMENTS)) {
+        	long commentId = Long.valueOf((String) commentIdStringObject);
+            PropertiesConfiguration commentProperties;
+            try {
+                commentProperties = this.confluencePackage.getObjectProperties(commentId);
+            } catch (ConfigurationException e) {
+                throw new FilterException("Failed to get comment properties", e);
+            }
+
+            pageComments.put(commentId, commentProperties);
+        }
+
+        int commentIndex = 0;
+        for (Long commentId : pageComments.keySet()) {
+        	//readComment(pageProperties, proxyFilter, pageTags);
+        	String objectName = getObjectName(pageProperties);
+        	FilterEventParameters commentParameters = new FilterEventParameters();               
+            
+            // Comment object
+            commentParameters.put(WikiObjectFilter.PARAMETER_NUMBER, commentIndex);
+            commentParameters.put(WikiObjectFilter.PARAMETER_CLASS_REFERENCE, "XWiki.XWikiComments");        
+            proxyFilter.beginWikiObject(objectName, commentParameters);
+            
+            // Comment class
+            FilterEventParameters commentClassParameters = new FilterEventParameters();
+            proxyFilter.beginWikiClass(commentClassParameters);
+                        
+            FilterEventParameters commentClassPropertyParameters = new FilterEventParameters();
+            
+            // <author> class property
+            proxyFilter.beginWikiClassProperty("author", "com.xpn.xwiki.objects.classes.UsersClass", commentClassPropertyParameters);
+            proxyFilter.onWikiClassPropertyField("cache", "0", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("displayType", "input", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("multiSelect", "0", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("name", "author", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("number", "1", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("picker", "1", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("prettyName", "Author", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("relationalStorage", "0", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("separator", " ", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("size", "30", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
+            proxyFilter.endWikiClassProperty("author", "com.xpn.xwiki.objects.classes.UsersClass", commentClassPropertyParameters);
+            
+            // <comment> class property
+            proxyFilter.beginWikiClassProperty("comment", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
+            proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("editor", null, new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("name", "comment", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("number", "5", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("prettyName", "Comment", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("rows", "5", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("size", "40", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
+            proxyFilter.endWikiClassProperty("comment", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
+            
+            // <date> class property
+            proxyFilter.beginWikiClassProperty("date", "com.xpn.xwiki.objects.classes.DateClass", commentClassPropertyParameters);
+            proxyFilter.onWikiClassPropertyField("dateFormat", "dd/MM/yyyy HH:mm:ss", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("emptyIsToday", "1", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("name", "date", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("number", "2", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("picker", "1", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("prettyName", "Date", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("size", "20", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
+            proxyFilter.endWikiClassProperty("date", "com.xpn.xwiki.objects.classes.DateClass", commentClassPropertyParameters);
+            
+            // <highlight> class property
+            proxyFilter.beginWikiClassProperty("highlight", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
+            proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("name", "highlight", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("number", "3", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("prettyName", "Highlighted Text", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("rows", "2", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("size", "40", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
+            proxyFilter.endWikiClassProperty("highlight", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
+            
+            // <originalSelection> class property
+            proxyFilter.beginWikiClassProperty("originalSelection", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
+            proxyFilter.onWikiClassPropertyField("contenttype", "PureText", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("editor", "PureText", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("name", "originalSelection", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("number", "6", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("prettyName", "Original Selection", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("rows", "5", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("size", "40", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
+            proxyFilter.endWikiClassProperty("originalSelection", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
+            
+            // <replyto> class property
+            proxyFilter.beginWikiClassProperty("replyto", "com.xpn.xwiki.objects.classes.NumberClass", commentClassPropertyParameters);
+            proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("name", "replyto", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("number", "4", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("numberType", "Integer", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("prettyName", "Reply To", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("size", "5", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
+            proxyFilter.endWikiClassProperty("replyto", "com.xpn.xwiki.objects.classes.NumberClass", commentClassPropertyParameters);
+            
+            // <selection> class property
+            proxyFilter.beginWikiClassProperty("selection", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
+            proxyFilter.onWikiClassPropertyField("contenttype", "PureText", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("editor", "PureText", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("name", "selection", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("number", "3", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("prettyName", "Selection", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("rows", "5", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("size", "40", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
+            proxyFilter.endWikiClassProperty("selection", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
+            
+            // <selectionLeftContext> class property
+            proxyFilter.beginWikiClassProperty("selectionLeftContext", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
+            proxyFilter.onWikiClassPropertyField("contenttype", "PureText", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("editor", "PureText", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("name", "selectionLeftContext", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("number", "4", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("prettyName", "Selection Left Context", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("rows", "5", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("size", "40", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
+            proxyFilter.endWikiClassProperty("selectionLeftContext", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
+            
+            // <selectionRightContext> class property
+            proxyFilter.beginWikiClassProperty("selectionRightContext", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
+            proxyFilter.onWikiClassPropertyField("contenttype", "PureText", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("editor", "PureText", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("name", "selectionRightContext", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("number", "5", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("prettyName", "Selection Right Context", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("rows", "5", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("size", "40", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
+            proxyFilter.endWikiClassProperty("selectionRightContext", "com.xpn.xwiki.objects.classes.TextAreaClass", commentClassPropertyParameters);
+            
+            // <state> class property
+            proxyFilter.beginWikiClassProperty("state", "com.xpn.xwiki.objects.classes.StringClass", commentClassPropertyParameters);
+            proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("name", "state", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("number", "8", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("prettyName", "State", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("size", "30", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
+            proxyFilter.endWikiClassProperty("state", "com.xpn.xwiki.objects.classes.StringClass", commentClassPropertyParameters);
+            
+            // <target> class property
+            proxyFilter.beginWikiClassProperty("target", "com.xpn.xwiki.objects.classes.PageClass", commentClassPropertyParameters);
+            proxyFilter.onWikiClassPropertyField("cache", "0", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("classname", null, new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("disabled", "0", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("displayType", "input", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("freeText", "discouraged", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("multiSelect", "0", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("name", "target", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("number", "7", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("picker", "1", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("prettyName", "Target", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("relationalStorage", "0", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("separator", " ", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("size", "30", new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("sql", null, new FilterEventParameters());
+            proxyFilter.onWikiClassPropertyField("unmodifiable", "0", new FilterEventParameters());
+            proxyFilter.endWikiClassProperty("target", "com.xpn.xwiki.objects.classes.PageClass", commentClassPropertyParameters);
+                     
+            proxyFilter.endWikiClass(commentClassParameters);
+            
+            // object properties
+            PropertiesConfiguration commentProperties = pageComments.get(commentId);
+            // TODO resolve user reference
+            String commentCreator = "xwiki:XWiki." + commentProperties.getString("creator");
+            // TODO parse comment content (currently plain HTML)
+            String commentText = this.confluencePackage.getCommentText(commentProperties, commentId);
+            Date commentDate = null;
+			try {
+				commentDate = this.confluencePackage.getDate(commentProperties, "creationDate");
+			} catch (java.text.ParseException e) {
+				if (this.properties.isVerbose()) {
+                    this.logger.error("Failed to parse date", e);
+                }
+			}		
+            
+            proxyFilter.onWikiObjectProperty("author", commentCreator, new FilterEventParameters());
+            proxyFilter.onWikiObjectProperty("comment", commentText, new FilterEventParameters());
+            proxyFilter.onWikiObjectProperty("date", commentDate, new FilterEventParameters());
+            proxyFilter.onWikiObjectProperty("highlight", "", new FilterEventParameters());
+            proxyFilter.onWikiObjectProperty("originalSelection", "", new FilterEventParameters());
+            // TODO get message id that was replied to
+            proxyFilter.onWikiObjectProperty("replyto", null, new FilterEventParameters());
+            proxyFilter.onWikiObjectProperty("selection", "", new FilterEventParameters());
+            proxyFilter.onWikiObjectProperty("selectionLeftContext", "", new FilterEventParameters());
+            proxyFilter.onWikiObjectProperty("selectionRightContext", "", new FilterEventParameters());
+            proxyFilter.onWikiObjectProperty("state", "", new FilterEventParameters());
+            proxyFilter.onWikiObjectProperty("target", "", new FilterEventParameters());
+            
+            proxyFilter.endWikiObject(objectName, commentParameters); 
+            
+            commentIndex++;
         }
 
         // < WikiDocumentRevision
@@ -726,47 +935,13 @@ public class ConfluenceInputFilterStream
     
     private void readPageTags(PropertiesConfiguration pageProperties, ConfluenceFilter proxyFilter,
     		Map<String, PropertiesConfiguration> pageTags) throws FilterException {
-    	FilterEventParameters pageTagsParameters = new FilterEventParameters();
-    	    
-        // get parent name from reference
-        String parentName = "";
-        try {
-            parentName = this.confluencePackage.getReferenceFromId(pageProperties, ConfluenceXMLPackage.KEY_PAGE_PARENT).getName();
-        } catch (Exception e) {
-            if (this.properties.isVerbose()) {
-                this.logger.warn("Failed to parse parent");
-            }
-        }
-        
-        // use space name if there is no parent
-        if (parentName.isEmpty()) {
-        	try {
-				parentName = this.confluencePackage.getSpaceName(Long.valueOf(pageProperties.getString(ConfluenceXMLPackage.KEY_PAGE_SPACE)));
-			} catch (NumberFormatException | ConfigurationException e) {
-				this.logger.warn("Failed to parse space");
-			}
-        }
-        
-        // get page name
-        String pageName = pageProperties.getString(ConfluenceXMLPackage.KEY_PAGE_TITLE);
-        
-        // create full page name from parent + title + WebHome
-        StringBuilder nameBuilder = new StringBuilder();
-        if (!parentName.isEmpty()) {
-        	nameBuilder.append(parentName);
-        	nameBuilder.append(".");
-        }
-        if (!pageName.isEmpty()) {
-        	nameBuilder.append(pageName);
-        	nameBuilder.append(".");
-        }
-        nameBuilder.append("WebHome");       
-        String fullName = nameBuilder.toString();
+    	FilterEventParameters pageTagsParameters = new FilterEventParameters();     
+        String objectName = getObjectName(pageProperties);
         
         // Tag object
         pageTagsParameters.put(WikiObjectFilter.PARAMETER_NUMBER, 0);
         pageTagsParameters.put(WikiObjectFilter.PARAMETER_CLASS_REFERENCE, "XWiki.TagClass");        
-        proxyFilter.beginWikiObject(fullName, pageTagsParameters);
+        proxyFilter.beginWikiObject(objectName, pageTagsParameters);
         
         // Tag class
         FilterEventParameters tagClassParameters = new FilterEventParameters();
@@ -809,7 +984,47 @@ public class ConfluenceInputFilterStream
         // <tags> object property
         proxyFilter.onWikiObjectProperty("tags", tagBuilder.toString(), new FilterEventParameters());
         
-        proxyFilter.endWikiObject(fullName, pageTagsParameters);
+        proxyFilter.endWikiObject(objectName, pageTagsParameters);
+    }
+    
+    private String getObjectName(PropertiesConfiguration pageProperties) {
+    	// get parent name from reference
+        String parentName = "";
+        try {
+            parentName = this.confluencePackage.getReferenceFromId(pageProperties, ConfluenceXMLPackage.KEY_PAGE_PARENT).getName();
+        } catch (Exception e) {
+            if (this.properties.isVerbose()) {
+                this.logger.warn("Failed to parse parent");
+            }
+        }
+        
+        // use space name if there is no parent
+        if (parentName.isEmpty()) {
+        	try {
+				parentName = this.confluencePackage.getSpaceName(Long.valueOf(pageProperties.getString(ConfluenceXMLPackage.KEY_PAGE_SPACE)));
+			} catch (NumberFormatException | ConfigurationException e) {
+				if (this.properties.isVerbose()) {
+					this.logger.warn("Failed to parse space");
+				}
+			}
+        }
+        
+        // get page name
+        String pageName = pageProperties.getString(ConfluenceXMLPackage.KEY_PAGE_TITLE);
+        
+        // create full page name from parent + title + WebHome
+        StringBuilder nameBuilder = new StringBuilder();
+        if (!parentName.isEmpty()) {
+        	nameBuilder.append(parentName);
+        	nameBuilder.append(".");
+        }
+        if (!pageName.isEmpty()) {
+        	nameBuilder.append(pageName);
+        	nameBuilder.append(".");
+        }
+        nameBuilder.append("WebHome");
+        
+        return nameBuilder.toString();
     }
 
     public PropertiesConfiguration getContentProperties(PropertiesConfiguration properties, String key)

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/input/ConfluenceInputFilterStream.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/input/ConfluenceInputFilterStream.java
@@ -557,7 +557,7 @@ public class ConfluenceInputFilterStream
         // Tags
         Map<String, PropertiesConfiguration> pageTags = new LinkedHashMap<>();
         for (Object tagIdStringObject : pageProperties.getList(ConfluenceXMLPackage.KEY_PAGE_LABELLINGS)) {
-        	long tagId = Long.valueOf((String) tagIdStringObject);
+            long tagId = Long.valueOf((String) tagIdStringObject);
             PropertiesConfiguration tagProperties;
             try {
                 tagProperties = this.confluencePackage.getObjectProperties(tagId);
@@ -570,7 +570,7 @@ public class ConfluenceInputFilterStream
         }
 
         if (!pageTags.isEmpty()) {
-        	readPageTags(pageProperties, proxyFilter, pageTags);
+            readPageTags(pageProperties, proxyFilter, pageTags);
         }
         
         // Comments
@@ -578,7 +578,7 @@ public class ConfluenceInputFilterStream
         Map<Long, Long> commentIndeces = new LinkedHashMap<>();
         int commentIndex = 0;
         for (Object commentIdStringObject : pageProperties.getList(ConfluenceXMLPackage.KEY_PAGE_COMMENTS)) {
-        	long commentId = Long.valueOf((String) commentIdStringObject);
+            long commentId = Long.valueOf((String) commentIdStringObject);
             PropertiesConfiguration commentProperties;
             try {
                 commentProperties = this.confluencePackage.getObjectProperties(commentId);
@@ -592,7 +592,7 @@ public class ConfluenceInputFilterStream
         }
 
         for (Long commentId : pageComments.keySet()) {
-        	readPageComment(pageProperties, proxyFilter, commentId, pageComments, commentIndeces);
+            readPageComment(pageProperties, proxyFilter, commentId, pageComments, commentIndeces);
         }
 
         // < WikiDocumentRevision
@@ -747,9 +747,9 @@ public class ConfluenceInputFilterStream
     }
     
     private void readPageTags(PropertiesConfiguration pageProperties, ConfluenceFilter proxyFilter,
-    		Map<String, PropertiesConfiguration> pageTags) throws FilterException 
+            Map<String, PropertiesConfiguration> pageTags) throws FilterException 
     {
-    	FilterEventParameters pageTagsParameters = new FilterEventParameters();     
+        FilterEventParameters pageTagsParameters = new FilterEventParameters();     
         String objectName = getObjectName(pageProperties);
         
         // Tag object
@@ -790,8 +790,8 @@ public class ConfluenceInputFilterStream
         StringBuilder tagBuilder = new StringBuilder();
         String prefix = "";
         for (String tag : pageTags.keySet()) {
-        	tagBuilder.append(prefix);
-        	tagBuilder.append(tag);
+            tagBuilder.append(prefix);
+            tagBuilder.append(tag);
             prefix = "|";
         }
         
@@ -802,11 +802,11 @@ public class ConfluenceInputFilterStream
     }
     
     private void readPageComment (PropertiesConfiguration pageProperties, ConfluenceFilter proxyFilter, 
-    		Long commentId, Map<Long, PropertiesConfiguration> pageComments, Map<Long, Long> commentIndeces)
-    		throws FilterException
+            Long commentId, Map<Long, PropertiesConfiguration> pageComments, Map<Long, Long> commentIndeces)
+            throws FilterException
     {
-    	String objectName = getObjectName(pageProperties);
-    	FilterEventParameters commentParameters = new FilterEventParameters();               
+        String objectName = getObjectName(pageProperties);
+        FilterEventParameters commentParameters = new FilterEventParameters();               
         
         // Comment object
         commentParameters.put(WikiObjectFilter.PARAMETER_NUMBER, commentIndeces.get(commentId));
@@ -971,20 +971,20 @@ public class ConfluenceInputFilterStream
         // creator
         String commentCreator;
         if (commentProperties.containsKey("creatorName")) {
-        	// old creator reference by name
-        	commentCreator = commentProperties.getString("creatorName");
+            // old creator reference by name
+            commentCreator = commentProperties.getString("creatorName");
         } else {
-        	// new creator reference by key
-        	commentCreator = commentProperties.getString("creator");
-        	try {
-				PropertiesConfiguration creatorProperties = this.confluencePackage.getUserProperties(commentCreator);
-				// replace dots in user names with underlines for XWiki compatibility
-				commentCreator = creatorProperties.getString("name").replace(".", "_");
-			} catch (ConfigurationException e) {
-				if (this.properties.isVerbose()) {
+            // new creator reference by key
+            commentCreator = commentProperties.getString("creator");
+            try {
+                PropertiesConfiguration creatorProperties = this.confluencePackage.getUserProperties(commentCreator);
+                // replace dots in user names with underlines for XWiki compatibility
+                commentCreator = creatorProperties.getString("name").replace(".", "_");
+            } catch (ConfigurationException e) {
+                if (this.properties.isVerbose()) {
                     this.logger.warn("Unable to get comment creator name, using id instead.", e);
                 }
-			}
+            }
         }
         String commentCreatorReference = "xwiki:XWiki." + commentCreator;
         
@@ -994,7 +994,7 @@ public class ConfluenceInputFilterStream
         String commentText = commentBodyContent;
         if (commentBodyContent != null && this.properties.isConvertToXWiki()) {
             try {
-            	commentText = convertToXWiki21(commentBodyContent, commentBodyType);
+                commentText = convertToXWiki21(commentBodyContent, commentBodyType);
             } catch (Exception e) {
                 this.logger.error("Failed to convert content of the comment with id [{}]", commentId, e);
             }
@@ -1003,9 +1003,9 @@ public class ConfluenceInputFilterStream
         // creation date
         Date commentDate = null;
         try {
-        	commentDate = this.confluencePackage.getDate(commentProperties, "creationDate");
+            commentDate = this.confluencePackage.getDate(commentProperties, "creationDate");
         } catch (java.text.ParseException e) {
-        	if (this.properties.isVerbose()) {
+            if (this.properties.isVerbose()) {
                 this.logger.error("Failed to parse date", e);
             }
         }
@@ -1013,8 +1013,8 @@ public class ConfluenceInputFilterStream
         // parent (replyto)
         Long parentIndex = null;
         if (commentProperties.containsKey("parent")) {
-        	Long parentId = commentProperties.getLong("parent");
-        	parentIndex = commentIndeces.get(parentId);
+            Long parentId = commentProperties.getLong("parent");
+            parentIndex = commentIndeces.get(parentId);
         }
         
         proxyFilter.onWikiObjectProperty("author", commentCreatorReference, new FilterEventParameters());
@@ -1034,7 +1034,7 @@ public class ConfluenceInputFilterStream
     
     private String getObjectName(PropertiesConfiguration pageProperties)
     {
-    	// get parent name from reference
+        // get parent name from reference
         String parentName = "";
         try {
             parentName = this.confluencePackage.getReferenceFromId(pageProperties, ConfluenceXMLPackage.KEY_PAGE_PARENT).getName();
@@ -1046,13 +1046,13 @@ public class ConfluenceInputFilterStream
         
         // use space name if there is no parent
         if (parentName.isEmpty()) {
-        	try {
-				parentName = this.confluencePackage.getSpaceName(Long.valueOf(pageProperties.getString(ConfluenceXMLPackage.KEY_PAGE_SPACE)));
-			} catch (NumberFormatException | ConfigurationException e) {
-				if (this.properties.isVerbose()) {
-					this.logger.warn("Failed to parse space");
-				}
-			}
+            try {
+                parentName = this.confluencePackage.getSpaceName(Long.valueOf(pageProperties.getString(ConfluenceXMLPackage.KEY_PAGE_SPACE)));
+            } catch (NumberFormatException | ConfigurationException e) {
+                if (this.properties.isVerbose()) {
+                    this.logger.warn("Failed to parse space");
+                }
+            }
         }
         
         // get page name
@@ -1061,12 +1061,12 @@ public class ConfluenceInputFilterStream
         // create full page name from parent + title + WebHome
         StringBuilder nameBuilder = new StringBuilder();
         if (!parentName.isEmpty()) {
-        	nameBuilder.append(parentName);
-        	nameBuilder.append(".");
+            nameBuilder.append(parentName);
+            nameBuilder.append(".");
         }
         if (!pageName.isEmpty()) {
-        	nameBuilder.append(pageName);
-        	nameBuilder.append(".");
+            nameBuilder.append(pageName);
+            nameBuilder.append(".");
         }
         nameBuilder.append("WebHome");
         

--- a/confluence-xml/src/test/resources/confluencexml/4.3.2.test
+++ b/confluence-xml/src/test/resources/confluencexml/4.3.2.test
@@ -352,6 +352,159 @@ To help you on your way, we've inserted some of our favourite macros on this hom
             </entry>
           </parameters>
         </p>
+        <wikiObject name="privatespace.privatespace Home.WebHome">
+          <p>
+            <parameters>
+              <entry>
+                <string>number</string>
+                <long>0</long>
+              </entry>
+              <entry>
+                <string>class_reference</string>
+                <string>XWiki.XWikiComments</string>
+              </entry>
+            </parameters>
+          </p>
+          <wikiClass>
+            <wikiClassProperty name="author" type="com.xpn.xwiki.objects.classes.UsersClass">
+              <wikiClassPropertyField name="cache" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="displayType" value="input"></wikiClassPropertyField>
+              <wikiClassPropertyField name="multiSelect" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="author"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="picker" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Author"></wikiClassPropertyField>
+              <wikiClassPropertyField name="relationalStorage" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="separator" value=" "></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="30"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="comment" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="comment"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Comment"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="date" type="com.xpn.xwiki.objects.classes.DateClass">
+              <wikiClassPropertyField name="dateFormat" value="dd/MM/yyyy HH:mm:ss"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="emptyIsToday" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="date"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="2"></wikiClassPropertyField>
+              <wikiClassPropertyField name="picker" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Date"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="20"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="highlight" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="highlight"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="3"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Highlighted Text"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="2"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="originalSelection" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="originalSelection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="6"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Original Selection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="replyto" type="com.xpn.xwiki.objects.classes.NumberClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="replyto"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="4"></wikiClassPropertyField>
+              <wikiClassPropertyField name="numberType" value="Integer"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Reply To"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="selection" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="selection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="3"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Selection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="selectionLeftContext" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="selectionLeftContext"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="4"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Selection Left Context"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="selectionRightContext" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="selectionRightContext"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Selection Right Context"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="state" type="com.xpn.xwiki.objects.classes.StringClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="state"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="8"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="State"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="30"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="target" type="com.xpn.xwiki.objects.classes.PageClass">
+              <wikiClassPropertyField name="cache" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="classname"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="displayType" value="input"></wikiClassPropertyField>
+              <wikiClassPropertyField name="freeText" value="discouraged"></wikiClassPropertyField>
+              <wikiClassPropertyField name="multiSelect" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="target"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="7"></wikiClassPropertyField>
+              <wikiClassPropertyField name="picker" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Target"></wikiClassPropertyField>
+              <wikiClassPropertyField name="relationalStorage" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="separator" value=" "></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="30"></wikiClassPropertyField>
+              <wikiClassPropertyField name="sql"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+          </wikiClass>
+          <wikiObjectProperty name="author" value="xwiki:XWiki.admin"></wikiObjectProperty>
+          <wikiObjectProperty name="comment" value="Comment on my private space"></wikiObjectProperty>
+          <wikiObjectProperty name="date">
+            <p>
+              <value t="java.util.Date">2013-10-14 15:37:34.250 UTC</value>
+            </p>
+          </wikiObjectProperty>
+          <wikiObjectProperty name="highlight" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="originalSelection" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="replyto"></wikiObjectProperty>
+          <wikiObjectProperty name="selection" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="selectionLeftContext" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="selectionRightContext" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="state" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="target" value=""></wikiObjectProperty>
+        </wikiObject>
       </wikiDocumentRevision>
     </wikiDocumentLocale>
   </wikiDocument>
@@ -547,6 +700,159 @@ Link to page 1 [[here&gt;&gt;doc:SPACE1.Page 1]]</string>
             </wikiClassProperty>
           </wikiClass>
           <wikiObjectProperty name="tags" value="tag1|favourite"></wikiObjectProperty>
+        </wikiObject>
+        <wikiObject name="space2 Home.Page 2.WebHome">
+          <p>
+            <parameters>
+              <entry>
+                <string>number</string>
+                <long>0</long>
+              </entry>
+              <entry>
+                <string>class_reference</string>
+                <string>XWiki.XWikiComments</string>
+              </entry>
+            </parameters>
+          </p>
+          <wikiClass>
+            <wikiClassProperty name="author" type="com.xpn.xwiki.objects.classes.UsersClass">
+              <wikiClassPropertyField name="cache" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="displayType" value="input"></wikiClassPropertyField>
+              <wikiClassPropertyField name="multiSelect" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="author"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="picker" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Author"></wikiClassPropertyField>
+              <wikiClassPropertyField name="relationalStorage" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="separator" value=" "></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="30"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="comment" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="comment"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Comment"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="date" type="com.xpn.xwiki.objects.classes.DateClass">
+              <wikiClassPropertyField name="dateFormat" value="dd/MM/yyyy HH:mm:ss"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="emptyIsToday" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="date"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="2"></wikiClassPropertyField>
+              <wikiClassPropertyField name="picker" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Date"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="20"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="highlight" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="highlight"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="3"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Highlighted Text"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="2"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="originalSelection" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="originalSelection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="6"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Original Selection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="replyto" type="com.xpn.xwiki.objects.classes.NumberClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="replyto"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="4"></wikiClassPropertyField>
+              <wikiClassPropertyField name="numberType" value="Integer"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Reply To"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="selection" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="selection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="3"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Selection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="selectionLeftContext" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="selectionLeftContext"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="4"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Selection Left Context"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="selectionRightContext" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="selectionRightContext"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Selection Right Context"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="state" type="com.xpn.xwiki.objects.classes.StringClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="state"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="8"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="State"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="30"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="target" type="com.xpn.xwiki.objects.classes.PageClass">
+              <wikiClassPropertyField name="cache" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="classname"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="displayType" value="input"></wikiClassPropertyField>
+              <wikiClassPropertyField name="freeText" value="discouraged"></wikiClassPropertyField>
+              <wikiClassPropertyField name="multiSelect" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="target"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="7"></wikiClassPropertyField>
+              <wikiClassPropertyField name="picker" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Target"></wikiClassPropertyField>
+              <wikiClassPropertyField name="relationalStorage" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="separator" value=" "></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="30"></wikiClassPropertyField>
+              <wikiClassPropertyField name="sql"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+          </wikiClass>
+          <wikiObjectProperty name="author" value="xwiki:XWiki.admin"></wikiObjectProperty>
+          <wikiObjectProperty name="comment" value="Comment on page 2"></wikiObjectProperty>
+          <wikiObjectProperty name="date">
+            <p>
+              <value t="java.util.Date">2013-10-14 15:34:23.725 UTC</value>
+            </p>
+          </wikiObjectProperty>
+          <wikiObjectProperty name="highlight" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="originalSelection" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="replyto"></wikiObjectProperty>
+          <wikiObjectProperty name="selection" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="selectionLeftContext" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="selectionRightContext" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="state" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="target" value=""></wikiObjectProperty>
         </wikiObject>
       </wikiDocumentRevision>
     </wikiDocumentLocale>
@@ -18931,6 +19237,159 @@ nzbO2eCi2LGbxjwtYZ5oo2rqiv8NRyb5/wA5VyXC08mOZwAAAABJRU5ErkJggg==</content>
           </wikiClass>
           <wikiObjectProperty name="tags" value="tag1"></wikiObjectProperty>
         </wikiObject>
+        <wikiObject name="space2.space2 Home.WebHome">
+          <p>
+            <parameters>
+              <entry>
+                <string>number</string>
+                <long>0</long>
+              </entry>
+              <entry>
+                <string>class_reference</string>
+                <string>XWiki.XWikiComments</string>
+              </entry>
+            </parameters>
+          </p>
+          <wikiClass>
+            <wikiClassProperty name="author" type="com.xpn.xwiki.objects.classes.UsersClass">
+              <wikiClassPropertyField name="cache" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="displayType" value="input"></wikiClassPropertyField>
+              <wikiClassPropertyField name="multiSelect" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="author"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="picker" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Author"></wikiClassPropertyField>
+              <wikiClassPropertyField name="relationalStorage" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="separator" value=" "></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="30"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="comment" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="comment"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Comment"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="date" type="com.xpn.xwiki.objects.classes.DateClass">
+              <wikiClassPropertyField name="dateFormat" value="dd/MM/yyyy HH:mm:ss"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="emptyIsToday" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="date"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="2"></wikiClassPropertyField>
+              <wikiClassPropertyField name="picker" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Date"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="20"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="highlight" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="highlight"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="3"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Highlighted Text"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="2"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="originalSelection" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="originalSelection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="6"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Original Selection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="replyto" type="com.xpn.xwiki.objects.classes.NumberClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="replyto"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="4"></wikiClassPropertyField>
+              <wikiClassPropertyField name="numberType" value="Integer"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Reply To"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="selection" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="selection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="3"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Selection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="selectionLeftContext" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="selectionLeftContext"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="4"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Selection Left Context"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="selectionRightContext" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="selectionRightContext"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Selection Right Context"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="state" type="com.xpn.xwiki.objects.classes.StringClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="state"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="8"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="State"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="30"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="target" type="com.xpn.xwiki.objects.classes.PageClass">
+              <wikiClassPropertyField name="cache" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="classname"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="displayType" value="input"></wikiClassPropertyField>
+              <wikiClassPropertyField name="freeText" value="discouraged"></wikiClassPropertyField>
+              <wikiClassPropertyField name="multiSelect" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="target"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="7"></wikiClassPropertyField>
+              <wikiClassPropertyField name="picker" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Target"></wikiClassPropertyField>
+              <wikiClassPropertyField name="relationalStorage" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="separator" value=" "></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="30"></wikiClassPropertyField>
+              <wikiClassPropertyField name="sql"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+          </wikiClass>
+          <wikiObjectProperty name="author" value="xwiki:XWiki.admin"></wikiObjectProperty>
+          <wikiObjectProperty name="comment" value="Comment on homepage of space 2"></wikiObjectProperty>
+          <wikiObjectProperty name="date">
+            <p>
+              <value t="java.util.Date">2013-10-14 15:35:40.689 UTC</value>
+            </p>
+          </wikiObjectProperty>
+          <wikiObjectProperty name="highlight" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="originalSelection" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="replyto"></wikiObjectProperty>
+          <wikiObjectProperty name="selection" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="selectionLeftContext" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="selectionRightContext" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="state" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="target" value=""></wikiObjectProperty>
+        </wikiObject>
       </wikiDocumentRevision>
     </wikiDocumentLocale>
   </wikiDocument>
@@ -25580,6 +26039,469 @@ cyAvPg0KPC9HbG9iYWxTZXR0aW5ncz4=</content>
             </parameters>
           </p>
         </wikiAttachment>
+        <wikiObject name="space1 Home.Page 1.WebHome">
+          <p>
+            <parameters>
+              <entry>
+                <string>number</string>
+                <long>0</long>
+              </entry>
+              <entry>
+                <string>class_reference</string>
+                <string>XWiki.XWikiComments</string>
+              </entry>
+            </parameters>
+          </p>
+          <wikiClass>
+            <wikiClassProperty name="author" type="com.xpn.xwiki.objects.classes.UsersClass">
+              <wikiClassPropertyField name="cache" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="displayType" value="input"></wikiClassPropertyField>
+              <wikiClassPropertyField name="multiSelect" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="author"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="picker" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Author"></wikiClassPropertyField>
+              <wikiClassPropertyField name="relationalStorage" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="separator" value=" "></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="30"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="comment" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="comment"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Comment"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="date" type="com.xpn.xwiki.objects.classes.DateClass">
+              <wikiClassPropertyField name="dateFormat" value="dd/MM/yyyy HH:mm:ss"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="emptyIsToday" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="date"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="2"></wikiClassPropertyField>
+              <wikiClassPropertyField name="picker" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Date"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="20"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="highlight" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="highlight"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="3"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Highlighted Text"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="2"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="originalSelection" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="originalSelection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="6"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Original Selection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="replyto" type="com.xpn.xwiki.objects.classes.NumberClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="replyto"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="4"></wikiClassPropertyField>
+              <wikiClassPropertyField name="numberType" value="Integer"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Reply To"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="selection" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="selection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="3"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Selection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="selectionLeftContext" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="selectionLeftContext"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="4"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Selection Left Context"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="selectionRightContext" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="selectionRightContext"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Selection Right Context"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="state" type="com.xpn.xwiki.objects.classes.StringClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="state"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="8"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="State"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="30"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="target" type="com.xpn.xwiki.objects.classes.PageClass">
+              <wikiClassPropertyField name="cache" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="classname"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="displayType" value="input"></wikiClassPropertyField>
+              <wikiClassPropertyField name="freeText" value="discouraged"></wikiClassPropertyField>
+              <wikiClassPropertyField name="multiSelect" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="target"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="7"></wikiClassPropertyField>
+              <wikiClassPropertyField name="picker" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Target"></wikiClassPropertyField>
+              <wikiClassPropertyField name="relationalStorage" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="separator" value=" "></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="30"></wikiClassPropertyField>
+              <wikiClassPropertyField name="sql"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+          </wikiClass>
+          <wikiObjectProperty name="author" value="xwiki:XWiki.admin"></wikiObjectProperty>
+          <wikiObjectProperty name="comment" value="comment 1"></wikiObjectProperty>
+          <wikiObjectProperty name="date">
+            <p>
+              <value t="java.util.Date">2013-10-14 15:29:09.540 UTC</value>
+            </p>
+          </wikiObjectProperty>
+          <wikiObjectProperty name="highlight" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="originalSelection" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="replyto"></wikiObjectProperty>
+          <wikiObjectProperty name="selection" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="selectionLeftContext" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="selectionRightContext" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="state" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="target" value=""></wikiObjectProperty>
+        </wikiObject>
+        <wikiObject name="space1 Home.Page 1.WebHome">
+          <p>
+            <parameters>
+              <entry>
+                <string>number</string>
+                <long>1</long>
+              </entry>
+              <entry>
+                <string>class_reference</string>
+                <string>XWiki.XWikiComments</string>
+              </entry>
+            </parameters>
+          </p>
+          <wikiClass>
+            <wikiClassProperty name="author" type="com.xpn.xwiki.objects.classes.UsersClass">
+              <wikiClassPropertyField name="cache" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="displayType" value="input"></wikiClassPropertyField>
+              <wikiClassPropertyField name="multiSelect" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="author"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="picker" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Author"></wikiClassPropertyField>
+              <wikiClassPropertyField name="relationalStorage" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="separator" value=" "></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="30"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="comment" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="comment"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Comment"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="date" type="com.xpn.xwiki.objects.classes.DateClass">
+              <wikiClassPropertyField name="dateFormat" value="dd/MM/yyyy HH:mm:ss"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="emptyIsToday" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="date"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="2"></wikiClassPropertyField>
+              <wikiClassPropertyField name="picker" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Date"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="20"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="highlight" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="highlight"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="3"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Highlighted Text"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="2"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="originalSelection" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="originalSelection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="6"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Original Selection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="replyto" type="com.xpn.xwiki.objects.classes.NumberClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="replyto"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="4"></wikiClassPropertyField>
+              <wikiClassPropertyField name="numberType" value="Integer"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Reply To"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="selection" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="selection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="3"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Selection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="selectionLeftContext" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="selectionLeftContext"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="4"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Selection Left Context"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="selectionRightContext" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="selectionRightContext"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Selection Right Context"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="state" type="com.xpn.xwiki.objects.classes.StringClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="state"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="8"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="State"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="30"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="target" type="com.xpn.xwiki.objects.classes.PageClass">
+              <wikiClassPropertyField name="cache" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="classname"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="displayType" value="input"></wikiClassPropertyField>
+              <wikiClassPropertyField name="freeText" value="discouraged"></wikiClassPropertyField>
+              <wikiClassPropertyField name="multiSelect" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="target"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="7"></wikiClassPropertyField>
+              <wikiClassPropertyField name="picker" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Target"></wikiClassPropertyField>
+              <wikiClassPropertyField name="relationalStorage" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="separator" value=" "></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="30"></wikiClassPropertyField>
+              <wikiClassPropertyField name="sql"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+          </wikiClass>
+          <wikiObjectProperty name="author" value="xwiki:XWiki.admin"></wikiObjectProperty>
+          <wikiObjectProperty name="comment" value="Answer of comment 1"></wikiObjectProperty>
+          <wikiObjectProperty name="date">
+            <p>
+              <value t="java.util.Date">2013-10-14 15:29:19.428 UTC</value>
+            </p>
+          </wikiObjectProperty>
+          <wikiObjectProperty name="highlight" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="originalSelection" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="replyto">
+            <p>
+              <value t="java.lang.Long">0</value>
+            </p>
+          </wikiObjectProperty>
+          <wikiObjectProperty name="selection" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="selectionLeftContext" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="selectionRightContext" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="state" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="target" value=""></wikiObjectProperty>
+        </wikiObject>
+        <wikiObject name="space1 Home.Page 1.WebHome">
+          <p>
+            <parameters>
+              <entry>
+                <string>number</string>
+                <long>2</long>
+              </entry>
+              <entry>
+                <string>class_reference</string>
+                <string>XWiki.XWikiComments</string>
+              </entry>
+            </parameters>
+          </p>
+          <wikiClass>
+            <wikiClassProperty name="author" type="com.xpn.xwiki.objects.classes.UsersClass">
+              <wikiClassPropertyField name="cache" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="displayType" value="input"></wikiClassPropertyField>
+              <wikiClassPropertyField name="multiSelect" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="author"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="picker" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Author"></wikiClassPropertyField>
+              <wikiClassPropertyField name="relationalStorage" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="separator" value=" "></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="30"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="comment" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="comment"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Comment"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="date" type="com.xpn.xwiki.objects.classes.DateClass">
+              <wikiClassPropertyField name="dateFormat" value="dd/MM/yyyy HH:mm:ss"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="emptyIsToday" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="date"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="2"></wikiClassPropertyField>
+              <wikiClassPropertyField name="picker" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Date"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="20"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="highlight" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="highlight"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="3"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Highlighted Text"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="2"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="originalSelection" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="originalSelection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="6"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Original Selection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="replyto" type="com.xpn.xwiki.objects.classes.NumberClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="replyto"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="4"></wikiClassPropertyField>
+              <wikiClassPropertyField name="numberType" value="Integer"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Reply To"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="selection" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="selection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="3"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Selection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="selectionLeftContext" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="selectionLeftContext"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="4"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Selection Left Context"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="selectionRightContext" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="selectionRightContext"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Selection Right Context"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="state" type="com.xpn.xwiki.objects.classes.StringClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="state"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="8"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="State"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="30"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="target" type="com.xpn.xwiki.objects.classes.PageClass">
+              <wikiClassPropertyField name="cache" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="classname"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="displayType" value="input"></wikiClassPropertyField>
+              <wikiClassPropertyField name="freeText" value="discouraged"></wikiClassPropertyField>
+              <wikiClassPropertyField name="multiSelect" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="target"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="7"></wikiClassPropertyField>
+              <wikiClassPropertyField name="picker" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Target"></wikiClassPropertyField>
+              <wikiClassPropertyField name="relationalStorage" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="separator" value=" "></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="30"></wikiClassPropertyField>
+              <wikiClassPropertyField name="sql"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+          </wikiClass>
+          <wikiObjectProperty name="author" value="xwiki:XWiki.admin"></wikiObjectProperty>
+          <wikiObjectProperty name="comment" value="Coment 2"></wikiObjectProperty>
+          <wikiObjectProperty name="date">
+            <p>
+              <value t="java.util.Date">2013-10-14 15:29:25.282 UTC</value>
+            </p>
+          </wikiObjectProperty>
+          <wikiObjectProperty name="highlight" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="originalSelection" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="replyto"></wikiObjectProperty>
+          <wikiObjectProperty name="selection" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="selectionLeftContext" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="selectionRightContext" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="state" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="target" value=""></wikiObjectProperty>
+        </wikiObject>
       </wikiDocumentRevision>
     </wikiDocumentLocale>
   </wikiDocument>
@@ -25678,6 +26600,160 @@ To help you on your way, we've inserted some of our favourite macros on this hom
             </entry>
           </parameters>
         </p>
+        <wikiObject name="space1.space1 Home.WebHome">
+          <p>
+            <parameters>
+              <entry>
+                <string>number</string>
+                <long>0</long>
+              </entry>
+              <entry>
+                <string>class_reference</string>
+                <string>XWiki.XWikiComments</string>
+              </entry>
+            </parameters>
+          </p>
+          <wikiClass>
+            <wikiClassProperty name="author" type="com.xpn.xwiki.objects.classes.UsersClass">
+              <wikiClassPropertyField name="cache" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="displayType" value="input"></wikiClassPropertyField>
+              <wikiClassPropertyField name="multiSelect" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="author"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="picker" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Author"></wikiClassPropertyField>
+              <wikiClassPropertyField name="relationalStorage" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="separator" value=" "></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="30"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="comment" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="comment"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Comment"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="date" type="com.xpn.xwiki.objects.classes.DateClass">
+              <wikiClassPropertyField name="dateFormat" value="dd/MM/yyyy HH:mm:ss"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="emptyIsToday" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="date"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="2"></wikiClassPropertyField>
+              <wikiClassPropertyField name="picker" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Date"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="20"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="highlight" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="highlight"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="3"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Highlighted Text"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="2"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="originalSelection" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="originalSelection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="6"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Original Selection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="replyto" type="com.xpn.xwiki.objects.classes.NumberClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="replyto"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="4"></wikiClassPropertyField>
+              <wikiClassPropertyField name="numberType" value="Integer"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Reply To"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="selection" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="selection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="3"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Selection"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="selectionLeftContext" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="selectionLeftContext"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="4"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Selection Left Context"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="selectionRightContext" type="com.xpn.xwiki.objects.classes.TextAreaClass">
+              <wikiClassPropertyField name="contenttype" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="editor" value="PureText"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="selectionRightContext"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Selection Right Context"></wikiClassPropertyField>
+              <wikiClassPropertyField name="rows" value="5"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="40"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="state" type="com.xpn.xwiki.objects.classes.StringClass">
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="state"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="8"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="State"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="30"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+            <wikiClassProperty name="target" type="com.xpn.xwiki.objects.classes.PageClass">
+              <wikiClassPropertyField name="cache" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="classname"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="displayType" value="input"></wikiClassPropertyField>
+              <wikiClassPropertyField name="freeText" value="discouraged"></wikiClassPropertyField>
+              <wikiClassPropertyField name="multiSelect" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="target"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="7"></wikiClassPropertyField>
+              <wikiClassPropertyField name="picker" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Target"></wikiClassPropertyField>
+              <wikiClassPropertyField name="relationalStorage" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="separator" value=" "></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="30"></wikiClassPropertyField>
+              <wikiClassPropertyField name="sql"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+            </wikiClassProperty>
+          </wikiClass>
+          <wikiObjectProperty name="author" value="xwiki:XWiki.admin"></wikiObjectProperty>
+          <wikiObjectProperty name="comment" value="Comment on space 1 web home
+This space is in favourit"></wikiObjectProperty>
+          <wikiObjectProperty name="date">
+            <p>
+              <value t="java.util.Date">2013-10-14 15:38:26.69 UTC</value>
+            </p>
+          </wikiObjectProperty>
+          <wikiObjectProperty name="highlight" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="originalSelection" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="replyto"></wikiObjectProperty>
+          <wikiObjectProperty name="selection" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="selectionLeftContext" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="selectionRightContext" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="state" value=""></wikiObjectProperty>
+          <wikiObjectProperty name="target" value=""></wikiObjectProperty>
+        </wikiObject>
       </wikiDocumentRevision>
     </wikiDocumentLocale>
   </wikiDocument>

--- a/confluence-xml/src/test/resources/confluencexml/4.3.2.test
+++ b/confluence-xml/src/test/resources/confluencexml/4.3.2.test
@@ -514,6 +514,40 @@ Link to page 1 [[here&gt;&gt;doc:SPACE1.Page 1]]</string>
             </entry>
           </parameters>
         </p>
+        <wikiObject name="space2 Home.Page 2.WebHome">
+          <p>
+            <parameters>
+              <entry>
+                <string>number</string>
+                <int>0</int>
+              </entry>
+              <entry>
+                <string>class_reference</string>
+                <string>XWiki.TagClass</string>
+              </entry>
+            </parameters>
+          </p>
+          <wikiClass>
+            <wikiClassProperty name="tags" type="com.xpn.xwiki.objects.classes.StaticListClass">
+              <wikiClassPropertyField name="cache" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="displayType" value="input"></wikiClassPropertyField>
+              <wikiClassPropertyField name="freeText" value="forbidden"></wikiClassPropertyField>
+              <wikiClassPropertyField name="largeStorage" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="multiSelect" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="tags"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Tags"></wikiClassPropertyField>
+              <wikiClassPropertyField name="relationalStorage" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="separator" value="|"></wikiClassPropertyField>
+              <wikiClassPropertyField name="separators" value="|,"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="30"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="values"></wikiClassPropertyField>
+            </wikiClassProperty>
+          </wikiClass>
+          <wikiObjectProperty name="tags" value="tag1|favourite"></wikiObjectProperty>
+        </wikiObject>
       </wikiDocumentRevision>
     </wikiDocumentLocale>
   </wikiDocument>
@@ -18863,6 +18897,40 @@ nzbO2eCi2LGbxjwtYZ5oo2rqiv8NRyb5/wA5VyXC08mOZwAAAABJRU5ErkJggg==</content>
             </parameters>
           </p>
         </wikiAttachment>
+        <wikiObject name="space2.space2 Home.WebHome">
+          <p>
+            <parameters>
+              <entry>
+                <string>number</string>
+                <int>0</int>
+              </entry>
+              <entry>
+                <string>class_reference</string>
+                <string>XWiki.TagClass</string>
+              </entry>
+            </parameters>
+          </p>
+          <wikiClass>
+            <wikiClassProperty name="tags" type="com.xpn.xwiki.objects.classes.StaticListClass">
+              <wikiClassPropertyField name="cache" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="displayType" value="input"></wikiClassPropertyField>
+              <wikiClassPropertyField name="freeText" value="forbidden"></wikiClassPropertyField>
+              <wikiClassPropertyField name="largeStorage" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="multiSelect" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="tags"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Tags"></wikiClassPropertyField>
+              <wikiClassPropertyField name="relationalStorage" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="separator" value="|"></wikiClassPropertyField>
+              <wikiClassPropertyField name="separators" value="|,"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="30"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="values"></wikiClassPropertyField>
+            </wikiClassProperty>
+          </wikiClass>
+          <wikiObjectProperty name="tags" value="tag1"></wikiObjectProperty>
+        </wikiObject>
       </wikiDocumentRevision>
     </wikiDocumentLocale>
   </wikiDocument>
@@ -18921,6 +18989,40 @@ nzbO2eCi2LGbxjwtYZ5oo2rqiv8NRyb5/wA5VyXC08mOZwAAAABJRU5ErkJggg==</content>
             </entry>
           </parameters>
         </p>
+        <wikiObject name="space1.WebHome">
+          <p>
+            <parameters>
+              <entry>
+                <string>number</string>
+                <int>0</int>
+              </entry>
+              <entry>
+                <string>class_reference</string>
+                <string>XWiki.TagClass</string>
+              </entry>
+            </parameters>
+          </p>
+          <wikiClass>
+            <wikiClassProperty name="tags" type="com.xpn.xwiki.objects.classes.StaticListClass">
+              <wikiClassPropertyField name="cache" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="displayType" value="input"></wikiClassPropertyField>
+              <wikiClassPropertyField name="freeText" value="forbidden"></wikiClassPropertyField>
+              <wikiClassPropertyField name="largeStorage" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="multiSelect" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="tags"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Tags"></wikiClassPropertyField>
+              <wikiClassPropertyField name="relationalStorage" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="separator" value="|"></wikiClassPropertyField>
+              <wikiClassPropertyField name="separators" value="|,"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="30"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="values"></wikiClassPropertyField>
+            </wikiClassProperty>
+          </wikiClass>
+          <wikiObjectProperty name="tags" value="favourite"></wikiObjectProperty>
+        </wikiObject>
       </wikiDocumentRevision>
     </wikiDocumentLocale>
   </wikiDocument>

--- a/confluence-xml/src/test/resources/confluencexml/4.3.2.test
+++ b/confluence-xml/src/test/resources/confluencexml/4.3.2.test
@@ -19550,7 +19550,20 @@ Content of the page including:
 11. 2c
 1. 3
 
-76 incomplete Saisissez la tâche ici et mentionnez le nom d'un utilisateur précédé du caractère @ pour la lui affecter 77 incomplete task 2 78 incomplete task 2.1 79 incomplete task 2.1.1 80 incomplete task 2.2 81 incomplete task 3 82 incomplete Task 4 for [[user:admin]]
+* ☐ Saisissez la tâche ici et mentionnez le nom d'un utilisateur précédé du caractère @ pour la lui affecter
+
+* ☐ task 2
+
+* ☐ task 2.1
+
+* ☐ task 2.1.1
+
+* ☐ task 2.2
+
+* ☐ task 3
+
+* ☐ Task 4 for [[user:admin]]\\
+
 [[image:attach:9391963529_96f9f9b16c_o.jpg]]
 
 [[image:attach:271360617.jpg]]
@@ -19683,7 +19696,20 @@ Content of the page including:
 11. 2c
 1. 3
 
-76 incomplete Saisissez la tâche ici et mentionnez le nom d'un utilisateur précédé du caractère @ pour la lui affecter 77 incomplete task 2 78 incomplete task 2.1 79 incomplete task 2.1.1 80 incomplete task 2.2 81 incomplete task 3 82 incomplete Task 4 for [[user:admin]]
+* ☐ Saisissez la tâche ici et mentionnez le nom d'un utilisateur précédé du caractère @ pour la lui affecter
+
+* ☐ task 2
+
+* ☐ task 2.1
+
+* ☐ task 2.1.1
+
+* ☐ task 2.2
+
+* ☐ task 3
+
+* ☐ Task 4 for [[user:admin]]\\
+
 [[image:attach:9391963529_96f9f9b16c_o.jpg]]
 
 [[image:attach:271360617.jpg]]
@@ -20026,7 +20052,20 @@ Content of the page including:
 11. 2c
 1. 3
 
-76 incomplete Saisissez la tâche ici et mentionnez le nom d'un utilisateur précédé du caractère @ pour la lui affecter 77 incomplete task 2 78 incomplete task 2.1 79 incomplete task 2.1.1 80 incomplete task 2.2 81 incomplete task 3 82 incomplete Task 4 for [[user:admin]]
+* ☐ Saisissez la tâche ici et mentionnez le nom d'un utilisateur précédé du caractère @ pour la lui affecter
+
+* ☐ task 2
+
+* ☐ task 2.1
+
+* ☐ task 2.1.1
+
+* ☐ task 2.2
+
+* ☐ task 3
+
+* ☐ Task 4 for [[user:admin]]\\
+
 [[image:attach:9391963529_96f9f9b16c_o.jpg]]
 
 [[image:attach:271360617.jpg]]
@@ -20369,7 +20408,20 @@ Content of the page including:
 11. 2c
 1. 3
 
-76 complete Saisissez la tâche ici et mentionnez le nom d'un utilisateur précédé du caractère @ pour la lui affecter 77 incomplete task 2 78 incomplete task 2.1 79 incomplete task 2.1.1 80 incomplete task 2.2 81 incomplete task 3 82 incomplete Task 4 for [[user:admin]]
+* ☑ Saisissez la tâche ici et mentionnez le nom d'un utilisateur précédé du caractère @ pour la lui affecter
+
+* ☐ task 2
+
+* ☐ task 2.1
+
+* ☐ task 2.1.1
+
+* ☐ task 2.2
+
+* ☐ task 3
+
+* ☐ Task 4 for [[user:admin]]\\
+
 [[image:attach:9391963529_96f9f9b16c_o.jpg]]
 
 [[image:attach:271360617.jpg]]
@@ -20712,8 +20764,20 @@ Content of the page including:
 11. 2c
 1. 3
 
-76 complete Task 1 is checked
- 77 incomplete task 2 78 incomplete task 2.1 79 incomplete task 2.1.1 80 incomplete task 2.2 81 incomplete task 3 82 incomplete Task 4 for [[user:admin]]
+* ☑ Task 1 is checked\\
+
+* ☐ task 2
+
+* ☐ task 2.1
+
+* ☐ task 2.1.1
+
+* ☐ task 2.2
+
+* ☐ task 3
+
+* ☐ Task 4 for [[user:admin]]\\
+
 [[image:attach:9391963529_96f9f9b16c_o.jpg]]
 
 [[image:attach:271360617.jpg]]
@@ -21056,8 +21120,20 @@ Content of the page including:
 11. 2c
 1. 3
 
-76 complete Task 1 is checked
- 77 incomplete task 2 78 incomplete task 2.1 79 incomplete task 2.1.1 80 incomplete task 2.2 81 incomplete task 3 82 incomplete Task 4 for [[user:admin]]
+* ☑ Task 1 is checked\\
+
+* ☐ task 2
+
+* ☐ task 2.1
+
+* ☐ task 2.1.1
+
+* ☐ task 2.2
+
+* ☐ task 3
+
+* ☐ Task 4 for [[user:admin]]\\
+
 [[image:attach:9391963529_96f9f9b16c_o.jpg]]
 
 [[image:attach:271360617.jpg]]
@@ -21407,8 +21483,20 @@ Content of the page including:
 11. 2c
 1. 3
 
-76 complete Task 1 is checked
- 77 incomplete task 2 78 incomplete task 2.1 79 incomplete task 2.1.1 80 incomplete task 2.2 81 incomplete task 3 82 incomplete Task 4 for [[user:admin]]
+* ☑ Task 1 is checked\\
+
+* ☐ task 2
+
+* ☐ task 2.1
+
+* ☐ task 2.1.1
+
+* ☐ task 2.2
+
+* ☐ task 3
+
+* ☐ Task 4 for [[user:admin]]\\
+
 [[image:attach:9391963529_96f9f9b16c_o.jpg]]
 
 [[image:attach:271360617.jpg]]

--- a/confluence-xml/src/test/resources/confluencexml/misc.test
+++ b/confluence-xml/src/test/resources/confluencexml/misc.test
@@ -52,6 +52,40 @@
             </entry>
           </parameters>
         </p>
+        <wikiObject name="Test XWIKI-9803.WebHome">
+          <p>
+            <parameters>
+              <entry>
+                <string>number</string>
+                <int>0</int>
+              </entry>
+              <entry>
+                <string>class_reference</string>
+                <string>XWiki.TagClass</string>
+              </entry>
+            </parameters>
+          </p>
+          <wikiClass>
+            <wikiClassProperty name="tags" type="com.xpn.xwiki.objects.classes.StaticListClass">
+              <wikiClassPropertyField name="cache" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="disabled" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="displayType" value="input"></wikiClassPropertyField>
+              <wikiClassPropertyField name="freeText" value="forbidden"></wikiClassPropertyField>
+              <wikiClassPropertyField name="largeStorage" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="multiSelect" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="name" value="tags"></wikiClassPropertyField>
+              <wikiClassPropertyField name="number" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="prettyName" value="Tags"></wikiClassPropertyField>
+              <wikiClassPropertyField name="relationalStorage" value="1"></wikiClassPropertyField>
+              <wikiClassPropertyField name="separator" value="|"></wikiClassPropertyField>
+              <wikiClassPropertyField name="separators" value="|,"></wikiClassPropertyField>
+              <wikiClassPropertyField name="size" value="30"></wikiClassPropertyField>
+              <wikiClassPropertyField name="unmodifiable" value="0"></wikiClassPropertyField>
+              <wikiClassPropertyField name="values"></wikiClassPropertyField>
+            </wikiClassProperty>
+          </wikiClass>
+          <wikiObjectProperty name="tags" value="favourite"></wikiObjectProperty>
+        </wikiObject>
       </wikiDocumentRevision>
     </wikiDocumentLocale>
   </wikiDocument>


### PR DESCRIPTION
This merge request incorporates various fixes we needed to migrate our company Confluence to XWiki. Sorry for the large amount of changes in one request. I tried to keep to the provided formatting/style as much as possible. The extension was tested with XWiki 12.10. The following changes were made:

XML:
- read users based on user keys (concerns [CONFLUENCE-39])
user keys are hexadecimal strings - do not fit in longs
read as strings instead, however this needed overloading for methods that assume long IDs
this extension was needed for the comment handling (to get the comment creator)

- import labels/tags (fixes [CONFLUENCE-63])
attaching class + object as seen in a xar export from our xwiki instance

- import comments (fixes [CONFLUENCE-46])
attaching class + objects as seen in a xar export from our xwiki instance
lots of similar calls for all the class properties - is there a better way for this?
object editor claims the "replyto" field is deprecated, but that is what was in the exported xar archive

XHTML:
had to add unnecessary javadoc comments and some wrong html tags due to checkstyle complaining

- add attachment in macro parameter as parameter "att--filename" (fixes [CONFLUENCE-32])
add handling in AttachmentTagHandler
works well for view-file and viewxls macros
att--filename chosen as it should not conflict with any other parameters
multiple attachment parameters will probably not work

- fix macros in `<pre>` tags not getting imported (fixes [CONFLUENCE-64])
our import was missing some drawio macros and we found all the missing ones to be inside `<pre>` tags
add handler for `<pre>` tags
accumulate content and pass to onVerbatim()

- handle key based user tags (concerns [CONFLUENCE-39])
handle "ri:userkey" parameter same as "ri:username" in UserTagHandler
only extracts the userkey and will create references to the id (not the actual users, for which we need the user name)
so this is not a full solution, but i could not think of a way to access the userkey to username mapping within the xhtml package
i guess it probably needs some larger structural change?

- handle `<time>` tags (should fix [CONFLUENCE-42] though i have not tested this in table cells)
add handler for `<time>` tags
simply extract the value of the "datetime" parameter and display it using onWord()

- support tasks lists (fixes [CONFLUENCE-65])
add handlers for task tags (task-list, task, task-id and task-status; task-body does not need handling as it should directly pass its content)
creates static checkboxes using unicode characters (since xwiki has no interactive checkbox support I know of)
list hierarchy is lost - all elements are displayed at the same level (could probably be solved with a stack object but it was not important enought to use time for it)

- adapt tests to support new functionality
adapt the expected output for the integration tests importing 4.3.2.xml.zip and misc.xml.zip