### PR TITLE
CONFLUENCE-105: URL macro parameter value is not imported in XWiki

### DIFF
--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/URLTagHandler.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/URLTagHandler.java
@@ -52,11 +52,12 @@ public class URLTagHandler extends TagHandler implements ConfluenceTagHandler
         Object container = context.getTagStack().getStackParameter(CONFLUENCE_CONTAINER);
 
         WikiParameter urlParameter = context.getParams().getParameter("ri:value");
-        if (urlParameter != null && container instanceof URLContainer) {
-            ((URLContainer) container).setURL(urlParameter.getValue());
-        } else if (urlParameter != null && container instanceof ConfluenceMacro) {
-            ConfluenceMacro macro = (ConfluenceMacro) container;
-            macro.parameters = macro.parameters.setParameter("url", urlParameter.getValue());
+        if (urlParameter != null) {
+            if (container instanceof URLContainer) {
+                ((URLContainer) container).setURL(urlParameter.getValue());
+            } else if (container instanceof ConfluenceMacro) {
+                context.getParentContext().appendContent(urlParameter.getValue());
+            }
         }
     }
 }

--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/URLTagHandler.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/URLTagHandler.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel;
 
+import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.MacroTagHandler.ConfluenceMacro;
 import org.xwiki.rendering.wikimodel.WikiParameter;
 import org.xwiki.rendering.wikimodel.xhtml.handler.TagHandler;
 import org.xwiki.rendering.wikimodel.xhtml.impl.TagContext;
@@ -53,6 +54,9 @@ public class URLTagHandler extends TagHandler implements ConfluenceTagHandler
         WikiParameter urlParameter = context.getParams().getParameter("ri:value");
         if (urlParameter != null && container instanceof URLContainer) {
             ((URLContainer) container).setURL(urlParameter.getValue());
+        } else if (urlParameter != null && container instanceof ConfluenceMacro) {
+            ConfluenceMacro macro = (ConfluenceMacro) container;
+            macro.parameters = macro.parameters.setParameter("url", urlParameter.getValue());
         }
     }
 }

--- a/confluence-syntax-xhtml/src/test/resources/confluence+xhtml10/specific/macro/macro6.test
+++ b/confluence-syntax-xhtml/src/test/resources/confluence+xhtml10/specific/macro/macro6.test
@@ -11,5 +11,5 @@
 .expect|event/1.0
 .#-----------------------------------------------------
 beginDocument
-onMacroStandalone [video] [url=http://host|uri=]
+onMacroStandalone [video] [uri=http://host]
 endDocument

--- a/confluence-syntax-xhtml/src/test/resources/confluence+xhtml10/specific/macro/macro6.test
+++ b/confluence-syntax-xhtml/src/test/resources/confluence+xhtml10/specific/macro/macro6.test
@@ -1,0 +1,15 @@
+.#-----------------------------------------------------
+.input|confluence+xhtml/1.0
+.# CONFLUENCE-105: URL macro parameter value is not imported in XWiki.
+.#-----------------------------------------------------
+<ac:structured-macro ac:name="video" ac:schema-version="1">
+  <ac:parameter ac:name="uri">
+    <ri:url ri:value="http://host"/>
+  </ac:parameter>
+</ac:structured-macro>
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+onMacroStandalone [video] [url=http://host|uri=]
+endDocument

--- a/confluence-xml/src/test/resources/confluencexml/5.9.test
+++ b/confluence-xml/src/test/resources/confluencexml/5.9.test
@@ -1532,13 +1532,13 @@ Flickr photo streams, Twitter streams, Google maps and many more.
 ===   
  ===
 
-{{widget url=""/}}
+{{widget url="https://www.youtube.com/watch?v=zy5ycJO4alo"/}}
 {{/layout-cell}}
 
 {{layout-cell}}
 
 
-{{widget url=""/}}
+{{widget url="https://maps.google.com/maps?q=Atlassian,+George+Street,+New+South+Wales,+Australia&amp;hl=en&amp;ll=-33.866572,151.207001&amp;spn=0.004321,0.008256&amp;sll=-33.870509,151.203707&amp;sspn=0.008641,0.016512&amp;oq=atlassian,&amp;hq=Atlassian,+George+Street,+New+South+Wales,+Australia&amp;radius=15000&amp;t=m&amp;z=18&amp;iwloc=A"/}}
 {{/layout-cell}}
 {{/layout-section}}
 


### PR DESCRIPTION
* add support for the url tag as a macro parameter
* add test for this case