### PR TITLE
CONFLUENCE-143: XML Parsing fails on some entities.xml files with BS (BACKSPACE) characters

### DIFF
--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/input/ConfluenceXMLPackage.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/input/ConfluenceXMLPackage.java
@@ -59,6 +59,7 @@ import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.annotation.InstantiationStrategy;
 import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
+import org.xwiki.contrib.confluence.filter.internal.WithoutBackSpacesReader;
 import org.xwiki.environment.Environment;
 import org.xwiki.filter.FilterException;
 import org.xwiki.filter.input.FileInputSource;
@@ -733,7 +734,7 @@ public class ConfluenceXMLPackage implements AutoCloseable
         this.tree.mkdir();
 
         try (InputStream stream = new FileInputStream(getEntities())) {
-            XMLStreamReader xmlReader = XML_INPUT_FACTORY.createXMLStreamReader(stream);
+            XMLStreamReader xmlReader = XML_INPUT_FACTORY.createXMLStreamReader(new WithoutBackSpacesReader(stream));
 
             xmlReader.nextTag();
 

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/WithoutBackSpacesReader.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/WithoutBackSpacesReader.java
@@ -1,0 +1,78 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.xwiki.contrib.confluence.filter.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+
+/**
+ * Reader removing the ASCII BS (8) character from the provided input stream.
+ * This is necessary because we have seen Confluence exports containing such characters which break XML parsing.
+ * @version $Id$
+ * @since 9.34
+ */
+public class WithoutBackSpacesReader extends Reader
+{
+    private InputStream is;
+
+    /**
+     * Convert this input stream into a reader that skips the BS characters.
+     * @param is the input stream from which to ignore the BS characters.
+     */
+    public WithoutBackSpacesReader(InputStream is)
+    {
+        this.is = is;
+    }
+
+    @Override
+    public int read(char[] cbuf, int off, int len) throws IOException
+    {
+        for (int i = 0; i < len; i++) {
+            int c = read();
+            if (c == -1) {
+                if (i == 0) {
+                    return -1;
+                }
+                return i;
+            }
+            cbuf[off + i] = (char) c;
+        }
+        return len;
+    }
+
+    @Override
+    public int read() throws IOException
+    {
+        int c1 = is.read();
+        if (c1 == 8) {
+            // Ignore the backspace character
+            return read();
+        }
+        return c1;
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        is.close();
+    }
+}

--- a/confluence-xml/src/test/resources/confluencexml/cdatazerowidthspace.test
+++ b/confluence-xml/src/test/resources/confluencexml/cdatazerowidthspace.test
@@ -1,0 +1,51 @@
+.#------------------------------------------------------------------------------
+.expect|filter+xml
+.#------------------------------------------------------------------------------
+<wikiSpace name="MySpace">
+  <wikiDocument name="WebHome">
+    <wikiDocumentLocale>
+      <p>
+        <parameters>
+          <entry>
+            <string>creation_author</string>
+            <string>XWiki.47826731</string>
+          </entry>
+          <entry>
+            <string>creation_date</string>
+            <date>2012-08-21 15:37:47.0 UTC</date>
+          </entry>
+          <entry>
+            <string>lastrevision</string>
+            <string>1</string>
+          </entry>
+        </parameters>
+      </p>
+      <wikiDocumentRevision revision="1">
+        <p>
+          <parameters>
+            <entry>
+              <string>revision_author</string>
+              <string>XWiki.47826731</string>
+            </entry>
+            <entry>
+              <string>revision_date</string>
+              <date>2016-10-11 14:47:37.0 UTC</date>
+            </entry>
+            <entry>
+              <string>revision_comment</string>
+              <string></string>
+            </entry>
+            <entry>
+              <string>title</string>
+              <string></string>
+            </entry>
+          </parameters>
+        </p>
+      </wikiDocumentRevision>
+    </wikiDocumentLocale>
+  </wikiDocument>
+</wikiSpace>
+.#------------------------------------------------------------------------------
+.input|confluence+xml
+.configuration.source=cdatazerowidthspace
+.#------------------------------------------------------------------------------

--- a/confluence-xml/src/test/resources/confluencexml/cdatazerowidthspace/entities.xml
+++ b/confluence-xml/src/test/resources/confluencexml/cdatazerowidthspace/entities.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hibernate-generic datetime="2023-10-02 11:40:11">
+    <object class="ConfluenceUserImpl" package="com.atlassian.confluence.user">
+        <id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+        <property name="name"><![CDATA[47826731]]></property>
+        <property name="lowerName"><![CDATA[47826731]]></property>
+        <property name="email"/>
+    </object>
+    <object class="SpaceDescription" package="com.atlassian.confluence.spaces">
+        <id name="id">45809845</id>
+        <property name="hibernateVersion">5</property>
+        <property name="title"/><property name="lowerTitle"/><collection name="bodyContents" class="java.util.Collection"><element class="BodyContent" package="com.atlassian.confluence.core"><id name="id">156868656</id>
+        </element>
+        </collection>
+        <property name="version">1</property>
+        <property name="creator" class="ConfluenceUserImpl" package="com.atlassian.confluence.user"><id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+        </property>
+        <property name="creationDate">2012-08-21 15:37:47.000</property>
+        <property name="lastModifier" class="ConfluenceUserImpl" package="com.atlassian.confluence.user"><id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+        </property>
+        <property name="lastModificationDate">2016-10-11 14:47:37.000</property>
+        <property name="versionComment"><![CDATA[]]></property>
+        <property name="contentStatus"><![CDATA[current]]></property>
+        <collection name="labellings" class="java.util.Collection"></collection>
+        <property name="space" class="Space" package="com.atlassian.confluence.spaces"><id name="id">46268417</id>
+        </property>
+    </object>
+    <object class="Space" package="com.atlassian.confluence.spaces">
+        <id name="id">46268417</id>
+        <property name="name"><![CDATA[My Space]]></property>
+        <property name="key"><![CDATA[MySpace]]></property>
+        <property name="lowerKey"><![CDATA[myspace]]></property>
+        <property name="description" class="SpaceDescription" package="com.atlassian.confluence.spaces"><id name="id">45809845</id>
+        </property>
+        <property name="homePage" class="Page" package="com.atlassian.confluence.pages"><id name="id">45809846</id></property>
+        <collection name="permissions" class="java.util.Collection"></collection>
+        <property name="creator" class="ConfluenceUserImpl" package="com.atlassian.confluence.user"><id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+        </property>
+        <property name="creationDate">2012-08-21 15:37:47.000</property>
+        <property name="lastModifier" class="ConfluenceUserImpl" package="com.atlassian.confluence.user"><id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+        </property>
+        <property name="lastModificationDate">2016-10-11 14:47:37.000</property>
+        <property name="spaceType">global</property>
+        <property name="spaceStatus" enum-class="SpaceStatus" package="com.atlassian.confluence.spaces">CURRENT</property>
+    </object>
+    <object class="BodyContent" package="com.atlassian.confluence.core">
+        <id name="id">156868656</id>
+        <property name="body"><![CDATA[<h2 style="text-align: center;"><strong>Hello world</strong></h2>]]></property>
+        <property name="content" class="Page" package="com.atlassian.confluence.pages"><id name="id">45809846</id></property>
+        <property name="bodyType">2</property>
+    </object>
+    <object class="Page" package="com.atlassian.confluence.pages">
+        <id name="id">45809846</id>
+        <property name="hibernateVersion">13</property>
+        <property name="title"><![CDATA[Alex Rodriguez]]></property>
+        <property name="lowerTitle"><![CDATA[alex rodriguez]]></property>
+        <collection name="bodyContents" class="java.util.Collection">
+            <element class="BodyContent" package="com.atlassian.confluence.core">
+                <id name="id">156868656</id>
+            </element>
+        </collection>
+        <collection name="outgoingLinks" class="java.util.Collection">
+        </collection>
+        <property name="version">1</property>
+        <property name="creator" class="ConfluenceUserImpl" package="com.atlassian.confluence.user">
+            <id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+        </property>
+        <property name="creationDate">2019-02-13 08:05:54.000</property>
+        <property name="lastModifier" class="ConfluenceUserImpl" package="com.atlassian.confluence.user">
+            <id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+        </property>
+        <property name="lastModificationDate">2019-02-13 08:16:56.000</property>
+        <property name="versionComment"><![CDATA[]]></property>
+        <property name="contentStatus"><![CDATA[draft]]></property>
+        <property name="space" class="Space" package="com.atlassian.confluence.spaces">
+            <id name="id">46268417</id>
+        </property>
+        <property name="position"/>
+    </object>
+</hibernate-generic>


### PR DESCRIPTION
This implementation puts a custom Reader between the input stream and the xml parser that removes BS characters.

It works but I'd like a review so someone can react if they see some drawback with this approach.