### PR TITLE
Misc: Renable checkstyle on ConfluenceConverterListener and apply some linting

### DIFF
--- a/confluence-xml/pom.xml
+++ b/confluence-xml/pom.xml
@@ -146,7 +146,6 @@
             <configuration>
               <excludes>
                 org/xwiki/contrib/confluence/filter/input/ConfluenceXMLPackage.java,
-                org/xwiki/contrib/confluence/filter/internal/input/ConfluenceConverterListener.java,
                 org/xwiki/contrib/confluence/filter/internal/input/ConfluenceInputFilterStream.java
               </excludes>
             </configuration>


### PR DESCRIPTION
This PR is not urgent. It reenables checkstyle on ConfluenceConverterListener by:
- Avoiding ore than 5 returns in a method. Not sure the result is more readable and it's the biggest reason I ask for a review
- Reducing branch complexity by creating an "enforceSlashes" method instead of doing the work in place to avoid an additional if in a method that already have some branches

Not sure the result is better, but does allow reenabling checkstyle, which I think is nice.

I also applied some suggestions from IntelliJ:
 - warnings about unnecessary regex escaping (imho indeed makes them a bit more readable but that's a matter of taste)
 - the removeParameter is inlined using a `removeIf` call, which makes the code a bit more declarative. This change is of course discutable and easily reverted. 

I guess reenabling checkstyle for ConfluenceXMLPackage and for ConfluenceInputFilterStream is another matter. It would be nice to be able to reenable it and ignore some of the rules related to the code being very long (which breakages do not actually make the classes hard to read and maintain in the case of those two classes IMHO). There are many coding style issues in them that would be easily caught but aren't since Checkstyle is disabled.