### PR TITLE
CONFLUENCE-181: Import fails when the export contains character U+0002

### DIFF
--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/input/ConfluenceXMLPackage.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/input/ConfluenceXMLPackage.java
@@ -65,7 +65,7 @@ import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.annotation.InstantiationStrategy;
 import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
-import org.xwiki.contrib.confluence.filter.internal.WithoutBackSpacesReader;
+import org.xwiki.contrib.confluence.filter.internal.WithoutControlCharactersReaders;
 import org.xwiki.environment.Environment;
 import org.xwiki.filter.FilterException;
 import org.xwiki.filter.input.FileInputSource;
@@ -836,7 +836,7 @@ public class ConfluenceXMLPackage implements AutoCloseable
         this.tree.mkdir();
 
         try (CountingInputStream s = new CountingInputStream(new BufferedInputStream(new FileInputStream(entities)))) {
-            XMLStreamReader xmlReader = XML_INPUT_FACTORY.createXMLStreamReader(new WithoutBackSpacesReader(s));
+            XMLStreamReader xmlReader = XML_INPUT_FACTORY.createXMLStreamReader(new WithoutControlCharactersReaders(s));
 
             xmlReader.nextTag();
 

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/input/ConfluenceXMLPackage.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/input/ConfluenceXMLPackage.java
@@ -65,7 +65,7 @@ import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.annotation.InstantiationStrategy;
 import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
-import org.xwiki.contrib.confluence.filter.internal.WithoutControlCharactersReaders;
+import org.xwiki.contrib.confluence.filter.internal.WithoutControlCharactersReader;
 import org.xwiki.environment.Environment;
 import org.xwiki.filter.FilterException;
 import org.xwiki.filter.input.FileInputSource;
@@ -836,7 +836,7 @@ public class ConfluenceXMLPackage implements AutoCloseable
         this.tree.mkdir();
 
         try (CountingInputStream s = new CountingInputStream(new BufferedInputStream(new FileInputStream(entities)))) {
-            XMLStreamReader xmlReader = XML_INPUT_FACTORY.createXMLStreamReader(new WithoutControlCharactersReaders(s));
+            XMLStreamReader xmlReader = XML_INPUT_FACTORY.createXMLStreamReader(new WithoutControlCharactersReader(s));
 
             xmlReader.nextTag();
 

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/WithoutControlCharactersReader.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/WithoutControlCharactersReader.java
@@ -29,7 +29,7 @@ import java.io.InputStream;
  * @version $Id$
  * @since 9.24.0
  */
-public class WithoutControlCharactersReaders extends InputStream
+public class WithoutControlCharactersReader extends InputStream
 {
     private InputStream is;
 
@@ -37,7 +37,7 @@ public class WithoutControlCharactersReaders extends InputStream
      * Convert this input stream into a reader that skips the BS characters.
      * @param is the input stream from which to ignore the BS characters.
      */
-    public WithoutControlCharactersReaders(InputStream is)
+    public WithoutControlCharactersReader(InputStream is)
     {
         this.is = is;
     }

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/WithoutControlCharactersReaders.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/WithoutControlCharactersReaders.java
@@ -24,12 +24,12 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /**
- * Reader removing the ASCII BS (8) and the ASCII FS character from the provided input stream.
+ * Reader removing the ASCII control characters except the line feed and carriage return characters from the input
  * This is necessary because we have seen Confluence exports containing such characters which break XML parsing.
  * @version $Id$
  * @since 9.24.0
  */
-public class WithoutBackSpacesReader extends InputStream
+public class WithoutControlCharactersReaders extends InputStream
 {
     private InputStream is;
 
@@ -37,7 +37,7 @@ public class WithoutBackSpacesReader extends InputStream
      * Convert this input stream into a reader that skips the BS characters.
      * @param is the input stream from which to ignore the BS characters.
      */
-    public WithoutBackSpacesReader(InputStream is)
+    public WithoutControlCharactersReaders(InputStream is)
     {
         this.is = is;
     }
@@ -62,9 +62,9 @@ public class WithoutBackSpacesReader extends InputStream
     public int read() throws IOException
     {
         int c1 = is.read();
-        if (c1 == 8 || c1 == 28) {
-            // Ignore the backspace and the FS characters
-            return read();
+        // Ignore ASCII control characters apart from the line feed (10) and carriage return (13) characters
+        while (c1 > 0 && c1 < 32 && c1 != 10 && c1 != 13) {
+            c1 = is.read();
         }
         return c1;
     }

--- a/confluence-xml/src/test/resources/confluencexml/cdatazerowidthspace/entities.xml
+++ b/confluence-xml/src/test/resources/confluencexml/cdatazerowidthspace/entities.xml
@@ -45,7 +45,7 @@
     </object>
     <object class="BodyContent" package="com.atlassian.confluence.core">
         <id name="id">156868656</id>
-        <property name="body"><![CDATA[<h2 style="text-align: center;"><strong>Hello world</strong></h2>]]></property>
+        <property name="body"><![CDATA[<h2 style="text-align: center;"><strong>Hello world</strong></h2>]]></property>
         <property name="content" class="Page" package="com.atlassian.confluence.pages"><id name="id">45809846</id></property>
         <property name="bodyType">2</property>
     </object>


### PR DESCRIPTION
* Filter all control characters apart from line feed and carriage return.
* Rename the class to reflect its purpose.

Jira issue: https://jira.xwiki.org/browse/CONFLUENCE-181

I unfortunately couldn't test this on an export with the actual problem, but the existing tests are passing.