### PR TITLE
CONFLUENCE-208: Avoid importing dummy empty paragraphs with class "auto-cursor-target"

### DIFF
--- a/confluence-xml/src/test/resources/confluencexml/auto-cursor-target.test
+++ b/confluence-xml/src/test/resources/confluencexml/auto-cursor-target.test
@@ -1,0 +1,43 @@
+.#------------------------------------------------------------------------------
+.expect|filter+xml
+.# Content conversions
+.#------------------------------------------------------------------------------
+<wikiSpace name="TestSpace">
+  <wikiDocument name="TestContent">
+    <wikiDocumentLocale>
+      <wikiDocumentRevision>
+        <p>
+          <parameters>
+            <entry>
+              <string>title</string>
+              <string>TestContent</string>
+            </entry>
+            <entry>
+              <string>content</string>
+              <string>= Introduction =
+
+\\
+
+XWiki is a wiki software</string>
+            </entry>
+            <entry>
+              <string>syntax</string>
+              <org.xwiki.rendering.syntax.Syntax>
+                <type>
+                  <name>XWiki</name>
+                  <id>xwiki</id>
+                  <variants class="empty-list"/>
+                </type>
+                <version>2.1</version>
+              </org.xwiki.rendering.syntax.Syntax>
+            </entry>
+          </parameters>
+        </p>
+      </wikiDocumentRevision>
+    </wikiDocumentLocale>
+  </wikiDocument>
+</wikiSpace>
+.#------------------------------------------------------------------------------
+.input|confluence+xml
+.configuration.source=auto-cursor-target
+.#------------------------------------------------------------------------------

--- a/confluence-xml/src/test/resources/confluencexml/auto-cursor-target/entities.xml
+++ b/confluence-xml/src/test/resources/confluencexml/auto-cursor-target/entities.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hibernate-generic>
+  <object class="Space" package="com.atlassian.confluence.spaces">
+    <id name="id">100</id>
+    <property name="name"><![CDATA[TestSpace]]></property>
+    <property name="key"><![CDATA[TestSpace]]></property>
+  </object>
+
+  <object class="Page" package="com.atlassian.confluence.pages">
+    <id name="id">10</id>
+    <property name="space" class="Space"
+      package="com.atlassian.confluence.spaces">
+      <id name="id">100</id>
+    </property>
+    <property name="title"><![CDATA[TestContent]]></property>
+    <collection name="bodyContents">
+      <element class="BodyContent" package="com.atlassian.confluence.core">
+        <id name="id">0</id>
+      </element>
+    </collection>
+    <property name="parent" class="Page" package="com.atlassian.confluence.pages">
+      <id name="id">42</id>
+    </property>
+  </object>
+
+  <object class="BodyContent" package="com.atlassian.confluence.core">
+    <id name="id">0</id>
+    <property name="body">
+      <![CDATA[
+        <h1 class="auto-cursor-target">Introduction</h1><p><br /></p><p class="auto-cursor-target"><br /></p>
+        <p class="auto-cursor-target">XWiki is a wiki software</p>
+      ]]>
+    </property>
+    <property name="content" class="Page"
+      package="com.atlassian.confluence.pages">
+      <id name="id">10</id>
+    </property>
+    <property name="bodyType">2</property>
+  </object>
+
+</hibernate-generic>


### PR DESCRIPTION
* Remove empty paragraphs with class "auto-cursor-target".
* For non-empty paragraphs and headings, remove the class.
* Add a test case with auto-cursor-target class.

Jira issue: https://jira.xwiki.org/browse/CONFLUENCE-208