### PR TITLE
CONFLUENCE-193: Incorrect parsing of pre tags

### DIFF
--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/PreformattedTagHandler.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/PreformattedTagHandler.java
@@ -20,7 +20,7 @@
 package org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel;
 
 import org.xwiki.rendering.wikimodel.WikiParameters;
-import org.xwiki.rendering.wikimodel.xhtml.handler.PreserveTagHandler;
+import org.xwiki.rendering.wikimodel.xhtml.handler.TagHandler;
 import org.xwiki.rendering.wikimodel.xhtml.impl.TagContext;
 
 /**
@@ -35,8 +35,16 @@ import org.xwiki.rendering.wikimodel.xhtml.impl.TagContext;
  * @version $Id$
  * @since 9.5
  */
-public class PreformattedTagHandler extends PreserveTagHandler implements ConfluenceTagHandler
+public class PreformattedTagHandler extends TagHandler implements ConfluenceTagHandler
 {
+    /**
+     * Default constructor.
+     */
+    public PreformattedTagHandler()
+    {
+        super(true);
+    }
+
     @Override
     protected void begin(TagContext context)
     {

--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/PreformattedTagHandler.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/PreformattedTagHandler.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel;
 
+import org.xwiki.rendering.wikimodel.WikiParameters;
+import org.xwiki.rendering.wikimodel.xhtml.handler.PreserveTagHandler;
 import org.xwiki.rendering.wikimodel.xhtml.impl.TagContext;
 
 /**
@@ -33,25 +35,21 @@ import org.xwiki.rendering.wikimodel.xhtml.impl.TagContext;
  * @version $Id$
  * @since 9.5
  */
-public class PreformattedTagHandler extends AbstractConfluenceTagHandler implements ConfluenceTagHandler
+public class PreformattedTagHandler extends PreserveTagHandler implements ConfluenceTagHandler
 {
-    /**
-     * Constructor (checkstyle complains that this comment is missing although the other classes don't have it).
-     */
-    public PreformattedTagHandler()
-    {
-        super(true);
-    }
-
     @Override
     protected void begin(TagContext context)
     {
-        setAccumulateContent(true);
+        WikiParameters wikiParameters = new WikiParameters();
+        wikiParameters = wikiParameters.setParameter("class", "code");
+        context.getScannerContext().beginDocument(wikiParameters);
+        context.getTagStack().setInsideBlockElement();
     }
 
     @Override
     protected void end(TagContext context)
     {
-        context.getScannerContext().onVerbatim(context.getContent(), false);
+        context.getTagStack().unsetInsideBlockElement();
+        context.getScannerContext().endDocument();
     }
 }

--- a/confluence-syntax-xhtml/src/test/resources/confluence+xhtml10/specific/preformat/preformat1.test
+++ b/confluence-syntax-xhtml/src/test/resources/confluence+xhtml10/specific/preformat/preformat1.test
@@ -1,0 +1,31 @@
+.#-----------------------------------------------------
+.input|confluence+xhtml/1.0
+.# Make sure any number of white spaces is ignored between non inline elements
+.#-----------------------------------------------------
+<pre>Some text <code>code1</code>
+and
+<code>code2</code> some other text</pre>
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+beginGroup [[class]=[code]]
+beginParagraph
+onWord [Some]
+onSpace
+onWord [text]
+onSpace
+onMacroInline [code] [language=none] [code1]
+onNewLine
+onWord [and]
+onNewLine
+onMacroInline [code] [language=none] [code2]
+onSpace
+onWord [some]
+onSpace
+onWord [other]
+onSpace
+onWord [text]
+endParagraph
+endGroup [[class]=[code]]
+endDocument

--- a/confluence-syntax-xhtml/src/test/resources/confluence+xhtml10/specific/preformat/preformat2.test
+++ b/confluence-syntax-xhtml/src/test/resources/confluence+xhtml10/specific/preformat/preformat2.test
@@ -1,0 +1,27 @@
+.#-----------------------------------------------------
+.input|confluence+xhtml/1.0
+.# Make sure any number of white spaces is ignored between non inline elements
+.#-----------------------------------------------------
+<pre>Some text <a href="https://domain.com/path/to/resource">link text</a> other text</pre>
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+beginGroup [[class]=[code]]
+beginParagraph
+onWord [Some]
+onSpace
+onWord [text]
+onSpace
+beginLink [Typed = [true] Type = [url] Reference = [https://domain.com/path/to/resource]] [false] [[shape]=[rect]]
+onWord [link]
+onSpace
+onWord [text]
+endLink [Typed = [true] Type = [url] Reference = [https://domain.com/path/to/resource]] [false] [[shape]=[rect]]
+onSpace
+onWord [other]
+onSpace
+onWord [text]
+endParagraph
+endGroup [[class]=[code]]
+endDocument

--- a/confluence-syntax-xhtml/src/test/resources/confluence+xhtml10/specific/table/table1.test
+++ b/confluence-syntax-xhtml/src/test/resources/confluence+xhtml10/specific/table/table1.test
@@ -34,24 +34,106 @@ beginTable
 beginTableRow
 beginTableHeadCell
 beginGroup
-onVerbatim [
-          th line 1
-
-
-          th line 2
-        ] [false]
+beginGroup [[class]=[code]]
+beginParagraph
+onNewLine
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onWord [th]
+onSpace
+onWord [line]
+onSpace
+onWord [1]
+onNewLine
+onNewLine
+onNewLine
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onWord [th]
+onSpace
+onWord [line]
+onSpace
+onWord [2]
+onNewLine
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+endParagraph
+endGroup [[class]=[code]]
 endGroup
 endTableHeadCell
 endTableRow
 beginTableRow
 beginTableCell
 beginGroup
-onVerbatim [
-          td line 1
-
-
-          td line 2
-        ] [false]
+beginGroup [[class]=[code]]
+beginParagraph
+onNewLine
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onWord [td]
+onSpace
+onWord [line]
+onSpace
+onWord [1]
+onNewLine
+onNewLine
+onNewLine
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onWord [td]
+onSpace
+onWord [line]
+onSpace
+onWord [2]
+onNewLine
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+endParagraph
+endGroup [[class]=[code]]
 endGroup
 endTableCell
 endTableRow


### PR DESCRIPTION
Fix for https://jira.xwiki.org/browse/CONFLUENCE-193
Before, the confluence syntax was converted to this:
![image](https://github.com/xwiki-contrib/confluence/assets/45433221/1f7e707f-4d56-459b-a93c-e151dc6c3e7a)

After the fix:
![image](https://github.com/xwiki-contrib/confluence/assets/45433221/4edfec4b-8cdf-49da-a165-51cad8b1cea7)

How it is rendered in confluence:
![image](https://github.com/xwiki-contrib/confluence/assets/45433221/d102920c-de37-4fa4-a9b6-78eb71807d59)
