### PR TITLE
CONFLUENCE-214: Table with personalised color cells have double class which leads to wrong rendering

### DIFF
--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/TableCellTagHandler.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/TableCellTagHandler.java
@@ -35,7 +35,7 @@ public class TableCellTagHandler extends TableDataTagHandler
     {
         super.begin(context);
 
-        beginDocument(context, context.getParams());
+        beginDocument(context);
     }
 
     @Override

--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/TableHeadTagHandler.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/TableHeadTagHandler.java
@@ -35,7 +35,7 @@ public class TableHeadTagHandler extends XWikiTableDataTagHandler
     {
         super.begin(context);
 
-        beginDocument(context, context.getParams());
+        beginDocument(context);
     }
 
     @Override

--- a/confluence-syntax-xhtml/src/test/resources/confluence+xhtml10/specific/table/table2.test
+++ b/confluence-syntax-xhtml/src/test/resources/confluence+xhtml10/specific/table/table2.test
@@ -1,0 +1,62 @@
+.#-----------------------------------------------------
+.input|confluence+xhtml/1.0
+.# Make sure that table cell parameters aren't copied to the nested group syntax.
+.#-----------------------------------------------------
+<table>
+  <tbody>
+    <tr>
+      <td style="text-align: center;">
+      <p style="text-align: left;">Disposer d'un mail (2)</p></td>
+      <td class="highlight-green" data-highlight-colour="green">Oui</td>
+      <td class="highlight-red" data-highlight-colour="red">Non</td>
+      <td class="highlight-red" data-highlight-colour="red"><span>Non</span></td>
+    </tr>
+  </tbody>
+</table>
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+beginTable
+beginTableRow
+beginTableCell [[style]=[text-align: center;]]
+beginGroup
+beginParagraph [[style]=[text-align: left;]]
+onWord [Disposer]
+onSpace
+onWord [d]
+onSpecialSymbol [']
+onWord [un]
+onSpace
+onWord [mail]
+onSpace
+onSpecialSymbol [(]
+onWord [2]
+onSpecialSymbol [)]
+endParagraph [[style]=[text-align: left;]]
+endGroup
+endTableCell [[style]=[text-align: center;]]
+beginTableCell [[class]=[highlight-green][data-highlight-colour]=[green]]
+beginGroup
+beginParagraph
+onWord [Oui]
+endParagraph
+endGroup
+endTableCell [[class]=[highlight-green][data-highlight-colour]=[green]]
+beginTableCell [[class]=[highlight-red][data-highlight-colour]=[red]]
+beginGroup
+beginParagraph
+onWord [Non]
+endParagraph
+endGroup
+endTableCell [[class]=[highlight-red][data-highlight-colour]=[red]]
+beginTableCell [[class]=[highlight-red][data-highlight-colour]=[red]]
+beginGroup
+beginParagraph
+onWord [Non]
+endParagraph
+endGroup
+endTableCell [[class]=[highlight-red][data-highlight-colour]=[red]]
+endTableRow
+endTable
+endDocument

--- a/confluence-xml/src/test/resources/confluencexml/confluence80tags.test
+++ b/confluence-xml/src/test/resources/confluencexml/confluence80tags.test
@@ -272,11 +272,9 @@ But with Confluence, you can bring all that information into one place.
 )))|(((
 Getting a project outlined and adding the right content are just the first steps. Now it's time for your team to weigh in. Confluence makes it easy to discuss your work - with your team, your boss, or your entire company - in the same place where you organized and created it.
 )))
-|(% colspan="1" %)(% colspan="1" %)
-(((
+|(% colspan="1" %)(((
 [[Confluence 101: create content with pages>>url:https://www.atlassian.com/collaboration/confluence-create-content-with-pages||shape="rect"]]
-)))|(% colspan="1" %)(% colspan="1" %)
-(((
+)))|(% colspan="1" %)(((
 Think of pages as a New Age "document." If Word docs were rotary phones, Confluence pages would be smart phones. A smart phone still makes calls (like their rotary counterparts), but it can do so much more than that
 )))
 


### PR DESCRIPTION
* Create a group syntax without parameters instead of copying the parameters.
* Adjusted the existing test that demonstrated the problem.
* Add a new test case with the exact syntax from the issue to verify the fix.

Jira issue: https://jira.xwiki.org/browse/CONFLUENCE-214