### PR TITLE
CONFLUENCE-255: Unknown macro confluence_emoticon after migration fro…

### DIFF
--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/EmoticonTagHandler.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/EmoticonTagHandler.java
@@ -27,11 +27,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Handles emojis.
- * Preceding whitespaces are handled by adding ac:emoticon to EMPTYVISIBLE_ELEMENTS
- * in ConfluenceXHTMLWhitespaceXMLFilter.
- * @since 9.48.0
+ * Handles emojis. Preceding whitespaces are handled by adding ac:emoticon to EMPTYVISIBLE_ELEMENTS in
+ * ConfluenceXHTMLWhitespaceXMLFilter.
+ *
  * @version $Id$
+ * @since 9.48.0
  */
 public class EmoticonTagHandler extends AbstractConfluenceTagHandler implements ConfluenceTagHandler
 {
@@ -58,6 +58,7 @@ public class EmoticonTagHandler extends AbstractConfluenceTagHandler implements 
      *  5. the mapping is in emojiMap. Save it and close the page or at least call clearInterval(t).
      */
     private static final Map<String, String> EMOJI_MAP = new HashMap<>();
+
     static {
         EMOJI_MAP.put(":smile:", "😄️");
         EMOJI_MAP.put(":laughing:", "😆️");
@@ -112,6 +113,7 @@ public class EmoticonTagHandler extends AbstractConfluenceTagHandler implements 
     }
 
     private static final Map<String, String> NAME_MAP = new HashMap<>();
+
     static {
         NAME_MAP.put("smile", "🙂️");
         NAME_MAP.put("sad", "😞️");
@@ -137,6 +139,7 @@ public class EmoticonTagHandler extends AbstractConfluenceTagHandler implements 
 
     /**
      * Default constructor.
+     *
      * @since 9.48.0
      */
     public EmoticonTagHandler()
@@ -149,7 +152,9 @@ public class EmoticonTagHandler extends AbstractConfluenceTagHandler implements 
     {
         WikiParameters params = context.getParams();
 
-        if (!sendFallback(context, params) && !sendShortName(context, params) && !sendName(context, params)) {
+        if (!sendFallback(context, params) && !sendEmojiId(context, params) && !sendShortName(context, params)
+            && !sendName(context, params))
+        {
             context.getScannerContext().onMacro("confluence_emoticon", params, null, true);
         }
 
@@ -201,6 +206,25 @@ public class EmoticonTagHandler extends AbstractConfluenceTagHandler implements 
             if (emoji != null && !emoji.isEmpty()) {
                 context.getScannerContext().onWord(emoji);
                 return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean sendEmojiId(TagContext context, WikiParameters params)
+    {
+        WikiParameter emojiIdParam = params.getParameter("ac:emoji-id");
+        if (emojiIdParam != null) {
+            String emojiId = emojiIdParam.getValue();
+            if (emojiId != null && !emojiId.isEmpty()) {
+                try {
+                    int emojiCodePoint = Integer.parseInt(emojiId, 16);
+                    if (Character.isValidCodePoint(emojiCodePoint)) {
+                        context.getScannerContext().onWord(Character.toString(emojiCodePoint));
+                        return true;
+                    }
+                } catch (NumberFormatException ignored) {
+                }
             }
         }
         return false;

--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/EmoticonTagHandler.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/EmoticonTagHandler.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xwiki.rendering.wikimodel.WikiParameter;
 import org.xwiki.rendering.wikimodel.WikiParameters;
 import org.xwiki.rendering.wikimodel.xhtml.impl.TagContext;
@@ -137,6 +139,8 @@ public class EmoticonTagHandler extends AbstractConfluenceTagHandler implements 
         NAME_MAP.put("blue-star", "🔵️");
     }
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(EmoticonTagHandler.class);
+
     /**
      * Default constructor.
      *
@@ -224,6 +228,7 @@ public class EmoticonTagHandler extends AbstractConfluenceTagHandler implements 
                         return true;
                     }
                 } catch (NumberFormatException ignored) {
+                    LOGGER.warn("Failed to parse the [ac:emoji-id] parameter with value [{}].", emojiId);
                 }
             }
         }

--- a/confluence-xml/src/test/resources/confluencexml/emoji.test
+++ b/confluence-xml/src/test/resources/confluencexml/emoji.test
@@ -27,7 +27,17 @@ Also {{confluence_emoticon ac:emoji-shortname=":hypothetical_unknown_emoji_with_
 
 Several emojis on the same line, no spaces between: 🙂🧐
 
-Named emojis: 🙂️ 😞️ 😛️ 😃️ 😉️ 👍️ 👎️ ℹ️ ✅️ ❌️ ⚠️ ➕️ ➖️ ❓️ 💡️ ⚪️ 🟡️ 🔴️ 🟢️ 🔵️</string>
+Named emojis: 🙂️ 😞️ 😛️ 😃️ 😉️ 👍️ 👎️ ℹ️ ✅️ ❌️ ⚠️ ➕️ ➖️ ❓️ 💡️ ⚪️ 🟡️ 🔴️ 🟢️ 🔵️
+
+Emojis that do not have a fallback attribute.
+
+Clipboard 📋
+
+Thought balloon 💭
+
+Check mark button ✅
+
+Emoji tag with wrong id and a shortname 😮‍💨</string>
               </entry>
               <entry>
                 <string>syntax</string>

--- a/confluence-xml/src/test/resources/confluencexml/emoji/entities.xml
+++ b/confluence-xml/src/test/resources/confluencexml/emoji/entities.xml
@@ -33,6 +33,11 @@
       <p>Also <ac:emoticon ac:emoji-shortname=":hypothetical_unknown_emoji_with_no_fallback" ac:unknown-parameters-are-kept="1f642" /></p>
       <p>Several emojis on the same line, no spaces between: <ac:emoticon ac:name="smile" ac:emoji-shortname=":slight_smile:" ac:emoji-id="1f642" ac:emoji-fallback="🙂" /><ac:emoticon ac:emoji-fallback="🧐" /></p>
       <p>Named emojis: <ac:emoticon ac:name="smile"/> <ac:emoticon ac:name="sad"/> <ac:emoticon ac:name="cheeky"/> <ac:emoticon ac:name="laugh"/> <ac:emoticon ac:name="wink"/> <ac:emoticon ac:name="thumbs-up"/> <ac:emoticon ac:name="thumbs-down"/> <ac:emoticon ac:name="information"/> <ac:emoticon ac:name="tick"/> <ac:emoticon ac:name="cross"/> <ac:emoticon ac:name="warning"/> <ac:emoticon ac:name="plus"/> <ac:emoticon ac:name="minus"/> <ac:emoticon ac:name="question"/> <ac:emoticon ac:name="light-on"/> <ac:emoticon ac:name="light-off"/> <ac:emoticon ac:name="yellow-star"/> <ac:emoticon ac:name="red-star"/> <ac:emoticon ac:name="green-star"/> <ac:emoticon ac:name="blue-star"/></p>
+      <p>Emojis that do not have a fallback attribute.</p>
+      <p>Clipboard <ac:emoticon ac:name="clipboard" ac:emoji-id="1f4cb" /></p>
+      <p>Thought balloon <ac:emoticon ac:name="thought balloon" ac:emoji-id="1f4ad" /></p>
+      <p>Check mark button <ac:emoticon ac:name="check mark button" ac:emoji-id="2705"/></p>
+      <p>Emoji tag with wrong id and a shortname <ac:emoticon ac:emoji-id="27g52" ac:emoji-shortname=":face_exhaling:" /></p>
     ]]></property>
     <property name="content" class="Page"
       package="com.atlassian.confluence.pages">


### PR DESCRIPTION
…m newer confluence versions

Emoticon tags coming from newer confluence versions do not have the `ac:emoji-fallback` attribute. If the emoticon shortname or name is not part of the internal name to unicode mapping, the tag will be handles as a macro.

To try to circumvent this issue, we can also take the `ac:emoji-id` attribute into consideration. Its value is the hex representation of the emoji.