### PR TITLE
"Failed to read package" error as result of migration from old Confluence instances for Windows users

### DIFF
--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/input/ConfluenceXMLPackage.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/input/ConfluenceXMLPackage.java
@@ -1380,7 +1380,7 @@ public class ConfluenceXMLPackage implements AutoCloseable
                 String idName = xmlReader.getAttributeValue(null, "name");
 
                 if (idName.equals(idProperty)) {
-                    id = fixCDataAndNL(xmlReader.getElementText());
+                    id = fixCDataAndNL(xmlReader.getElementText()).replace(":", "=");
 
                     properties.setProperty(KEY_ID, id);
                 } else {
@@ -1917,12 +1917,12 @@ public class ConfluenceXMLPackage implements AutoCloseable
 
     private File getObjectFolder(String folderName, String objectId)
     {
-        return new File(getObjectsFolder(folderName), objectId);
+        return new File(getObjectsFolder(folderName), objectId.replace(":", "="));
     }
 
     private File getObjectFolder(File folder, String objectId)
     {
-        return new File(folder, objectId);
+        return new File(folder, objectId.replace(":", "="));
     }
 
     private File getPagePropertiesFile(long pageId)

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/input/ConfluenceXMLPackage.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/input/ConfluenceXMLPackage.java
@@ -1816,6 +1816,11 @@ public class ConfluenceXMLPackage implements AutoCloseable
             .replace('\u2029', '\n');
     }
 
+    private String escapeWindowsFolderName(String folderName)
+    {
+        return folderName.replace(":", "=");
+    }
+
     private Long readObjectReference(XMLStreamReader xmlReader) throws FilterException, XMLStreamException
     {
         xmlReader.nextTag();
@@ -1917,12 +1922,12 @@ public class ConfluenceXMLPackage implements AutoCloseable
 
     private File getObjectFolder(String folderName, String objectId)
     {
-        return new File(getObjectsFolder(folderName), objectId.replace(":", "="));
+        return new File(getObjectsFolder(folderName), escapeWindowsFolderName(objectId));
     }
 
     private File getObjectFolder(File folder, String objectId)
     {
-        return new File(folder, objectId.replace(":", "="));
+        return new File(folder, escapeWindowsFolderName(objectId));
     }
 
     private File getPagePropertiesFile(long pageId)

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/input/ConfluenceXMLPackage.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/input/ConfluenceXMLPackage.java
@@ -1818,7 +1818,7 @@ public class ConfluenceXMLPackage implements AutoCloseable
 
     private String escapeWindowsFolderName(String folderName)
     {
-        return folderName.replace(":", "=");
+        return folderName.replace("[<>:\"/\\|?*]", "");
     }
 
     private Long readObjectReference(XMLStreamReader xmlReader) throws FilterException, XMLStreamException

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/input/ConfluenceXMLPackage.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/input/ConfluenceXMLPackage.java
@@ -63,6 +63,7 @@ import javax.xml.stream.XMLStreamReader;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
 import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.io.FileSystem;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.input.CloseShieldInputStream;
 import org.apache.commons.io.input.CountingInputStream;
@@ -1818,7 +1819,7 @@ public class ConfluenceXMLPackage implements AutoCloseable
 
     private String escapeWindowsFolderName(String folderName)
     {
-        return folderName.replace("[<>:\"/\\|?*]", "");
+        return FileSystem.getCurrent().toLegalFileName(folderName, '_');
     }
 
     private Long readObjectReference(XMLStreamReader xmlReader) throws FilterException, XMLStreamException

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/input/ConfluenceXMLPackage.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/input/ConfluenceXMLPackage.java
@@ -1380,7 +1380,7 @@ public class ConfluenceXMLPackage implements AutoCloseable
                 String idName = xmlReader.getAttributeValue(null, "name");
 
                 if (idName.equals(idProperty)) {
-                    id = fixCDataAndNL(xmlReader.getElementText()).replace(":", "=");
+                    id = fixCDataAndNL(xmlReader.getElementText());
 
                     properties.setProperty(KEY_ID, id);
                 } else {


### PR DESCRIPTION
The PR fixes https://jira.xwiki.org/projects/CONFLUENCE/issues/CONFLUENCE-254

The problem is caused by certain user id's that contain the ":" character. The proposed solution simply replaces the said character with an "=". Since there were no reports of ids containing other characters, I considered this would suffice