### PR TITLE
CONFLUENCE-271: Create a converter for macros that need to be converted into a group

### DIFF
--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/MacroToContentConverter.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/MacroToContentConverter.java
@@ -24,6 +24,8 @@ import org.xwiki.rendering.syntax.Syntax;
 
 /**
  * Converts a macro call to a group, retaining the id, class and content.
+ *
+ * @since 9.51.1
  */
 @Component(hints = { "ul", "legend", "auihorizontalnav", "auibuttongroup", "auihorizontalnavpage", "tableenhancer",
     "footnote" })

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/MacroToContentConverter.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/MacroToContentConverter.java
@@ -1,0 +1,77 @@
+package org.xwiki.contrib.confluence.filter.internal.macros;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.manager.ComponentLookupException;
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.contrib.confluence.filter.input.ConfluenceInputContext;
+import org.xwiki.contrib.confluence.filter.input.ConfluenceInputProperties;
+import org.xwiki.rendering.block.MacroBlock;
+import org.xwiki.rendering.block.XDOM;
+import org.xwiki.rendering.listener.Listener;
+import org.xwiki.rendering.parser.ParseException;
+import org.xwiki.rendering.parser.Parser;
+import org.xwiki.rendering.syntax.Syntax;
+
+/**
+ * Converts a macro call to a group, retaining the id, class and content.
+ */
+@Component(hints = { "ul", "legend", "auihorizontalnav", "auibuttongroup", "auihorizontalnavpage", "tableenhancer",
+    "footnote" })
+@Singleton
+public class MacroToContentConverter extends AbstractMacroConverter
+{
+    private static final String DIV_CLASS_FORMAT = "confluence_%s_content";
+
+    private static final String HTML_ATTRIBUTE_ID = "id";
+
+    private static final String HTML_ATTRIBUTE_CLASS = "class";
+
+    @Inject
+    private ConfluenceInputContext context;
+
+    @Inject
+    private ComponentManager componentManager;
+
+    @Override
+    public void toXWiki(String id, Map<String, String> parameters, String content, boolean inline, Listener listener)
+    {
+        Map<String, String> divWrapperParams = new HashMap<>();
+
+        List<String> classes = new ArrayList<>();
+        classes.add(String.format(DIV_CLASS_FORMAT, id));
+        if (parameters.containsKey(HTML_ATTRIBUTE_CLASS)) {
+            classes.add(parameters.get(HTML_ATTRIBUTE_CLASS));
+        }
+        divWrapperParams.put(HTML_ATTRIBUTE_CLASS, String.join(" ", classes));
+
+        if (parameters.containsKey(HTML_ATTRIBUTE_ID)) {
+            divWrapperParams.put(HTML_ATTRIBUTE_ID, parameters.get(HTML_ATTRIBUTE_ID));
+        }
+
+        listener.beginGroup(divWrapperParams);
+        ConfluenceInputProperties inputProperties = context.getProperties();
+        Syntax macroContentSyntax = inputProperties == null ? null : inputProperties.getMacroContentSyntax();
+        String syntaxId = macroContentSyntax != null ? macroContentSyntax.toIdString() : Syntax.XWIKI_2_1.toIdString();
+        String newContent = toXWikiContent(id, parameters, content);
+        try {
+            Parser parser = componentManager.getInstance(Parser.class, syntaxId);
+            XDOM contentXDOM = parser.parse(new StringReader(newContent));
+            contentXDOM.getChildren().forEach(child -> child.traverse(listener));
+        } catch (ComponentLookupException | ParseException e) {
+            new MacroBlock("error", Collections.emptyMap(),
+                String.format("Failed to parse the content of the [%s] macro with the syntax [%s].", id, syntaxId),
+                false).traverse(listener);
+        }
+        listener.endGroup(divWrapperParams);
+    }
+}

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/MacroToContentConverter.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/MacroToContentConverter.java
@@ -1,3 +1,22 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
 package org.xwiki.contrib.confluence.filter.internal.macros;
 
 import java.io.StringReader;
@@ -25,6 +44,7 @@ import org.xwiki.rendering.syntax.Syntax;
 /**
  * Converts a macro call to a group, retaining the id, class and content.
  *
+ * @version $Id$
  * @since 9.51.1
  */
 @Component(hints = { "ul", "legend", "auihorizontalnav", "auibuttongroup", "auihorizontalnavpage", "tableenhancer",

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/TextParamToContentConverter.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/TextParamToContentConverter.java
@@ -1,0 +1,21 @@
+package org.xwiki.contrib.confluence.filter.internal.macros;
+
+import java.util.Map;
+
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+
+/**
+ * Converts a macro call into a group, using the value of the "text" parameter as its content.
+ */
+@Component(hints = { "cfm-footnote", "cfm-tooltip", "tooltip" })
+@Singleton
+public class TextParamToContentConverter extends MacroToContentConverter
+{
+    @Override
+    protected String toXWikiContent(String confluenceId, Map<String, String> parameters, String confluenceContent)
+    {
+        return parameters.getOrDefault("text", "");
+    }
+}

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/TextParamToContentConverter.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/TextParamToContentConverter.java
@@ -1,3 +1,22 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
 package org.xwiki.contrib.confluence.filter.internal.macros;
 
 import java.util.Map;
@@ -9,6 +28,7 @@ import org.xwiki.component.annotation.Component;
 /**
  * Converts a macro call into a group, using the value of the "text" parameter as its content.
  *
+ * @version $Id$
  * @since 9.51.1
  */
 @Component(hints = { "cfm-footnote", "cfm-tooltip", "tooltip" })

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/TextParamToContentConverter.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/TextParamToContentConverter.java
@@ -8,6 +8,8 @@ import org.xwiki.component.annotation.Component;
 
 /**
  * Converts a macro call into a group, using the value of the "text" parameter as its content.
+ *
+ * @since 9.51.1
  */
 @Component(hints = { "cfm-footnote", "cfm-tooltip", "tooltip" })
 @Singleton

--- a/confluence-xml/src/main/resources/META-INF/components.txt
+++ b/confluence-xml/src/main/resources/META-INF/components.txt
@@ -14,8 +14,10 @@ org.xwiki.contrib.confluence.filter.internal.macros.AnchorMacroConverter
 org.xwiki.contrib.confluence.filter.internal.macros.DefaultMacroConverter
 org.xwiki.contrib.confluence.filter.internal.macros.IncludeMacroConverter
 org.xwiki.contrib.confluence.filter.internal.macros.JiraMacroConverter
+org.xwiki.contrib.confluence.filter.internal.macros.MacroToContentConverter
 org.xwiki.contrib.confluence.filter.internal.macros.MentionMacroConverter
 org.xwiki.contrib.confluence.filter.internal.macros.NoformatMacroConverter
+org.xwiki.contrib.confluence.filter.internal.macros.TextParamToContentConverter
 org.xwiki.contrib.confluence.filter.internal.macros.WarningMacroConverter
 org.xwiki.contrib.confluence.filter.internal.macros.SpacesMacroConverter
 org.xwiki.contrib.confluence.filter.internal.macros.IframeMacroConverter

--- a/confluence-xml/src/test/resources/confluencexml/macroToGroup.test
+++ b/confluence-xml/src/test/resources/confluencexml/macroToGroup.test
@@ -1,0 +1,159 @@
+.#------------------------------------------------------------------------------
+.expect|filter+xml
+.#------------------------------------------------------------------------------
+<wikiSpace name="MySpace">
+  <wikiDocument name="WebHome">
+    <wikiDocumentLocale>
+      <p>
+        <parameters>
+          <entry>
+            <string>creation_author</string>
+            <string>XWiki.Teo</string>
+          </entry>
+          <entry>
+            <string>creation_date</string>
+            <date>2012-08-21 15:37:47.0 UTC</date>
+          </entry>
+          <entry>
+            <string>lastrevision</string>
+            <string>1</string>
+          </entry>
+        </parameters>
+      </p>
+      <wikiDocumentRevision revision="1">
+        <p>
+          <parameters>
+            <entry>
+              <string>revision_author</string>
+              <string>XWiki.Teo</string>
+            </entry>
+            <entry>
+              <string>revision_date</string>
+              <date>2016-10-11 14:47:37.0 UTC</date>
+            </entry>
+            <entry>
+              <string>revision_comment</string>
+              <string></string>
+            </entry>
+            <entry>
+              <string>title</string>
+              <string>My Space</string>
+            </entry>
+            <entry>
+              <string>content</string>
+              <string>
+
+= {{id name="MySpaceHome-CFMFootNote"/}}CFMFootNote =
+
+(% id="j61cfghrf8" class="confluence_cfm-footnote_content" %)
+(((
+Hello there, general kenobi. how are you doing? Im doing very well. thank u
+)))
+
+= {{id name="MySpaceHome-cfmTooltip"/}}cfmTooltip =
+
+(% id="0s1ra5xwsnad" class="confluence_cfm-tooltip_content" %)
+(((
+This is some tooltip
+)))
+
+= {{id name="MySpaceHome-Footnote"/}}Footnote =
+
+(% class="confluence_footnote_content" %)
+(((
+This is some **footnote**.
+)))
+
+= {{id name="MySpaceHome-Tooltip"/}}Tooltip =
+
+(% id="someId" class="confluence_tooltip_content" %)
+(((
+Some text
+)))
+
+= {{id name="MySpaceHome-UL"/}}UL =
+
+(% id="someId" class="confluence_ul_content SomeClass" %)
+(((
+Something
+
+Something2
+
+Something3?
+)))
+
+\\
+
+= {{id name="MySpaceHome-Legend"/}}Legend =
+
+(% class="confluence_legend_content" %)
+(((
+Something
+)))
+
+= {{id name="MySpaceHome-AUIHorizontalNav"/}}AUIHorizontalNav =
+
+(% id="SomeID" class="confluence_auihorizontalnav_content SomeClass" %)
+(((
+Some content. That is **also** rich text
+)))
+
+\\
+
+= {{id name="MySpaceHome-AUIButtonGroup"/}}AUIButtonGroup =
+
+(% id="SomeID" class="confluence_auibuttongroup_content SomeClass" %)
+(((
+Some **content**
+)))
+
+\\
+
+= {{id name="MySpaceHome-AUIHorizontalNavPage"/}}AUIHorizontalNavPage =
+
+(% id="someID" class="confluence_auihorizontalnavpage_content someClass" %)
+(((
+Some content?
+)))
+
+\\
+
+= {{id name="MySpaceHome-TableEnhancer"/}}TableEnhancer =
+
+(% class="confluence_tableenhancer_content" %)
+(((
+|=(((
+Some title
+)))|=(((
+Some title2
+)))
+|(((
+Some element
+)))|(((
+Some element
+)))
+)))
+
+</string>
+            </entry>
+            <entry>
+              <string>syntax</string>
+              <org.xwiki.rendering.syntax.Syntax>
+                <type>
+                  <name>XWiki</name>
+                  <id>xwiki</id>
+                  <variants class="empty-list"/>
+                </type>
+                <version>2.1</version>
+              </org.xwiki.rendering.syntax.Syntax>
+            </entry>
+          </parameters>
+        </p>
+      </wikiDocumentRevision>
+    </wikiDocumentLocale>
+  </wikiDocument>
+</wikiSpace>
+.#------------------------------------------------------------------------------
+.input|confluence+xml
+.configuration.source=macroToGroup
+.#------------------------------------------------------------------------------

--- a/confluence-xml/src/test/resources/confluencexml/macroToGroup/entities.xml
+++ b/confluence-xml/src/test/resources/confluencexml/macroToGroup/entities.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hibernate-generic datetime="2023-10-02 11:40:11">
+  <object class="ConfluenceUserImpl" package="com.atlassian.confluence.user">
+    <id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+    <property name="name"><![CDATA[Teo]]></property>
+    <property name="lowerName"><![CDATA[Smecherus]]></property>
+    <property name="email"><![CDATA[teo@email.com]]></property>
+  </object>
+  <object class="Page" package="com.atlassian.confluence.spaces">
+    <id name="id">45809845</id>
+    <property name="hibernateVersion">5</property>
+    <property name="title">My Space Home</property>
+    <property name="lowerTitle">my space home</property>
+    <collection name="bodyContents" class="java.util.Collection"><element class="BodyContent" package="com.atlassian.confluence.core"><id name="id">156868656</id>
+    </element>
+    </collection>
+    <property name="version">1</property>
+    <property name="creator" class="ConfluenceUserImpl" package="com.atlassian.confluence.user"><id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+    </property>
+    <property name="creationDate">2012-08-21 15:37:47.000</property>
+    <property name="lastModifier" class="ConfluenceUserImpl" package="com.atlassian.confluence.user"><id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+    </property>
+    <property name="lastModificationDate">2016-10-11 14:47:37.000</property>
+    <property name="versionComment"><![CDATA[]]></property>
+    <property name="contentStatus"><![CDATA[current]]></property>
+    <collection name="labellings" class="java.util.Collection"></collection>
+    <property name="space" class="Space" package="com.atlassian.confluence.spaces"><id name="id">46268417</id>
+    </property>
+    <collection name="attachments" class="java.util.Collection(com.atlassian.confluence.core.ContentEntityObject.attachments)"><element class="Attachment" package="com.atlassian.confluence.pages"><id name="id">134204920</id></element></collection>
+  </object>
+  <object class="Space" package="com.atlassian.confluence.spaces">
+    <id name="id">46268417</id>
+    <property name="name"><![CDATA[My Space]]></property>
+    <property name="key"><![CDATA[MySpace]]></property>
+    <property name="lowerKey"><![CDATA[myspace]]></property>
+    <property name="homePage" class="Page" package="com.atlassian.confluence.pages"><id name="id">45809845</id></property>
+    <collection name="permissions" class="java.util.Collection"></collection>
+    <property name="creator" class="ConfluenceUserImpl" package="com.atlassian.confluence.user"><id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+    </property>
+    <property name="creationDate">2012-08-21 15:37:47.000</property>
+    <property name="lastModifier" class="ConfluenceUserImpl" package="com.atlassian.confluence.user"><id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+    </property>
+    <property name="lastModificationDate">2016-10-11 14:47:37.000</property>
+    <property name="spaceType">global</property>
+    <property name="spaceStatus" enum-class="SpaceStatus" package="com.atlassian.confluence.spaces">CURRENT</property>
+  </object>
+  <object class="BodyContent" package="com.atlassian.confluence.core">
+    <id name="id">156868656</id>
+    <property name="body"><![CDATA[
+    <p></p>
+    <h1>CFMFootNote</h1>
+    <ac:structured-macro ac:name="cfm-footnote" ac:schema-version="1"
+        ac:local-id="09fb9453-4b39-4deb-a1c1-a459ee1eb6f5"
+        ac:macro-id="bc880543-2512-4982-97fb-a9eb625a92b6">
+        <ac:parameter ac:name="an.spaceKey">TEOS</ac:parameter>
+        <ac:parameter ac:name="text">Hello there, general kenobi. how are you doing?
+            Im doing very well. thank u</ac:parameter>
+        <ac:parameter ac:name="id">j61cfghrf8</ac:parameter>
+    </ac:structured-macro>
+    <h1>cfmTooltip</h1>
+    <ac:structured-macro ac:name="cfm-tooltip" ac:schema-version="1"
+        ac:local-id="9e4bff11-e8e0-4f6d-87cc-05f556e8f054"
+        ac:macro-id="b53ddb88-a74a-4cde-b86d-b611e13de84f">
+        <ac:parameter ac:name="an.spaceKey">TEOS</ac:parameter>
+        <ac:parameter ac:name="previewTheme">dark</ac:parameter>
+        <ac:parameter ac:name="text">This is some tooltip</ac:parameter>
+        <ac:parameter ac:name="id">0s1ra5xwsnad</ac:parameter>
+    </ac:structured-macro>
+    <h1>Footnote</h1>
+    <ac:structured-macro ac:name="footnote" ac:schema-version="1"
+        ac:macro-id="4d0c7e18-1acb-464a-8384-ccddddb7f1a3">
+        <ac:parameter ac:name="atlassian-macro-output-type">INLINE</ac:parameter>
+        <ac:rich-text-body>
+            <p>This is some <strong>footnote</strong>.</p>
+        </ac:rich-text-body>
+    </ac:structured-macro>
+    <h1>Tooltip</h1>
+    <p>
+        <ac:structured-macro ac:name="tooltip" ac:schema-version="1"
+            ac:macro-id="266cbff9-d10e-404f-8c6c-702c90a3fe2b">
+            <ac:parameter ac:name="id">someId</ac:parameter>
+            <ac:parameter ac:name="text">Some text</ac:parameter>
+            <ac:parameter ac:name="direction">S</ac:parameter>
+        </ac:structured-macro>
+    </p>
+    <h1>UL</h1>
+    <ac:structured-macro ac:name="ul" ac:schema-version="1"
+        ac:macro-id="471cdea3-8a53-482b-8496-de85f6792c67">
+        <ac:parameter ac:name="style">width: 150px</ac:parameter>
+        <ac:parameter ac:name="id">someId</ac:parameter>
+        <ac:parameter ac:name="dir">ltr</ac:parameter>
+        <ac:parameter ac:name="lang">ro</ac:parameter>
+        <ac:parameter ac:name="title">Some title</ac:parameter>
+        <ac:parameter ac:name="class">SomeClass</ac:parameter>
+        <ac:rich-text-body>
+            <p>Something</p>
+            <p>Something2</p>
+            <p>Something3?</p>
+        </ac:rich-text-body>
+    </ac:structured-macro>
+    <p>
+        <br />
+    </p>
+    <h1>Legend</h1>
+    <ac:structured-macro ac:name="legend">
+        <ac:rich-text-body>
+            <p>Something</p>
+        </ac:rich-text-body>
+    </ac:structured-macro>
+    <h1>AUIHorizontalNav</h1>
+    <ac:structured-macro ac:name="auihorizontalnav" ac:schema-version="1"
+        ac:macro-id="0843be4c-6e4e-49b9-ac3b-ae7e49ba80a5">
+        <ac:parameter ac:name="id">SomeID</ac:parameter>
+        <ac:parameter ac:name="title">Some title</ac:parameter>
+        <ac:parameter ac:name="class">SomeClass</ac:parameter>
+        <ac:rich-text-body>
+            <p>Some content. That is <strong>also</strong> rich text</p>
+        </ac:rich-text-body>
+    </ac:structured-macro>
+    <p>
+        <br />
+    </p>
+    <h1>AUIButtonGroup</h1>
+    <ac:structured-macro ac:name="auibuttongroup" ac:schema-version="1"
+        ac:macro-id="290b2323-eb56-49e5-9396-3e09cdda12de">
+        <ac:parameter ac:name="id">SomeID</ac:parameter>
+        <ac:parameter ac:name="title">Some text on hover</ac:parameter>
+        <ac:parameter ac:name="class">SomeClass</ac:parameter>
+        <ac:parameter ac:name="atlassian-macro-output-type">INLINE</ac:parameter>
+        <ac:rich-text-body>
+            <p>Some <strong>content</strong></p>
+        </ac:rich-text-body>
+    </ac:structured-macro>
+    <p>
+        <br />
+    </p>
+    <h1>AUIHorizontalNavPage</h1>
+    <ac:structured-macro ac:name="auihorizontalnavpage" ac:schema-version="1"
+        ac:macro-id="bfe9afb4-f3d7-475b-8307-8ff862945d7b">
+        <ac:parameter ac:name="id">someID</ac:parameter>
+        <ac:parameter ac:name="title">Some title</ac:parameter>
+        <ac:parameter ac:name="class">someClass</ac:parameter>
+        <ac:rich-text-body>
+            <p>Some content?</p>
+        </ac:rich-text-body>
+    </ac:structured-macro>
+    <p>
+        <br />
+    </p>
+    <h1>TableEnhancer</h1>
+    <ac:structured-macro ac:name="tableenhancer" ac:schema-version="1"
+        ac:macro-id="890a0b1b-c11a-4d71-9049-f77f0674fb90">
+        <ac:parameter ac:name="unaccentedSorting">true</ac:parameter>
+        <ac:parameter ac:name="rowNumbers">onceBeforeSorting</ac:parameter>
+        <ac:parameter ac:name="rowNumbersBgColor">green</ac:parameter>
+        <ac:parameter ac:name="decimalMark">, (comma)</ac:parameter>
+        <ac:parameter ac:name="totalLine">true</ac:parameter>
+        <ac:rich-text-body>
+            <table>
+                <colgroup>
+                    <col />
+                    <col />
+                </colgroup>
+                <tbody>
+                    <tr>
+                        <th scope="col">Some title</th>
+                        <th scope="col">Some title2</th>
+                    </tr>
+                    <tr>
+                        <td>Some element</td>
+                        <td>Some element</td>
+                    </tr>
+                </tbody>
+            </table>
+        </ac:rich-text-body>
+    </ac:structured-macro>
+    <p></p>
+]]></property>
+    <property name="content" class="Page" package="com.atlassian.confluence.pages"><id name="id">45809845</id></property>
+    <property name="bodyType">2</property>
+  </object>
+</hibernate-generic>


### PR DESCRIPTION
Changes needed to convert the following confluence macros to xwiki: cfm-footnote, footnote, cfm-tooltip, tooltip, ul, legend, auihorizontalnav, auibuttongroup, auihorizontalnavpage, tableenhancer

tooltip, cfm-tooltip and cfm-footnote will be converted to a group that will contain the value of the "text" parameter. In confluence, these macros were displaying the contents of the specified parameter.

cfm-footnote, ul, legend, auihorizontalnav, auibuttongroup, auihorizontalnavpage, tableenhancer will be converted to a group wrapping their content. 