### PR TITLE
CONFLUENCE-290: Link tags not handled properly when inside a macro pa…

### DIFF
--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/ConfluenceXHTMLParser.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/ConfluenceXHTMLParser.java
@@ -71,6 +71,7 @@ import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.PageTagHandl
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.PlainTextBodyTagHandler;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.PlainTextLinkBodyTagHandler;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.PreformattedTagHandler;
+import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.ReferenceTagHandler;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.RichTextBodyTagHandler;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.SpaceTagHandler;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.TableCellTagHandler;
@@ -198,7 +199,7 @@ public class ConfluenceXHTMLParser extends AbstractWikiModelParser
         handlers.put("h4", handler);
         handlers.put("h5", handler);
         handlers.put("h6", handler);
-        handlers.put("a", createXWikiReferenceTagHandler());
+        handlers.put("a", new ReferenceTagHandler(createXWikiReferenceTagHandler()));
         handlers.put("p", new ConfluenceParagraphTagHandler());
         handlers.put("li", new ConfluenceListItemTagHandler());
         handlers.put("ul", new ConfluenceUnorderedListTagHandler());

--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/ReferenceTagHandler.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/ReferenceTagHandler.java
@@ -1,3 +1,22 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
 package org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel;
 
 import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XWikiReferenceTagHandler;
@@ -17,11 +36,17 @@ import static org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.Confl
  *     <a href="https://www.bing.com/images/search?q=icon">https://www.bing.com/images/search?q=icon</a>
  *   </ac:parameter>
  * </ac:structured-macro>
+ *
+ * @version $Id$
+ * @since 9.57.0
  */
 public class ReferenceTagHandler extends TagHandler
 {
     private final XWikiReferenceTagHandler tagHandler;
 
+    /**
+     * @param tagHandler the default XWikiReference tag handler.
+     */
     public ReferenceTagHandler(XWikiReferenceTagHandler tagHandler)
     {
         super(tagHandler.isContentContainer());

--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/ReferenceTagHandler.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/ReferenceTagHandler.java
@@ -1,0 +1,65 @@
+package org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel;
+
+import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XWikiReferenceTagHandler;
+import org.xwiki.rendering.wikimodel.WikiParameter;
+import org.xwiki.rendering.wikimodel.xhtml.handler.TagHandler;
+import org.xwiki.rendering.wikimodel.xhtml.impl.TagContext;
+import org.xwiki.rendering.wikimodel.xhtml.impl.TagStack;
+
+import static org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.AbstractMacroParameterTagHandler.IN_CONFLUENCE_PARAMETER;
+import static org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.ConfluenceTagHandler.CONFLUENCE_CONTAINER;
+
+/**
+ * Handles <a> tags present in confluence parameters.
+ * Example:
+ * <ac:structured-macro ac:name="macroName">
+ *   <ac:parameter ac:name="linkParam">
+ *     <a href="https://www.bing.com/images/search?q=icon">https://www.bing.com/images/search?q=icon</a>
+ *   </ac:parameter>
+ * </ac:structured-macro>
+ */
+public class ReferenceTagHandler extends TagHandler
+{
+    private final XWikiReferenceTagHandler tagHandler;
+
+    public ReferenceTagHandler(XWikiReferenceTagHandler tagHandler)
+    {
+        super(tagHandler.isContentContainer());
+        this.tagHandler = tagHandler;
+    }
+
+    @Override
+    public void initialize(TagStack stack)
+    {
+        this.tagHandler.initialize(stack);
+    }
+
+    @Override
+    protected void begin(TagContext context)
+    {
+        if (context.getTagStack().getStackParameter(IN_CONFLUENCE_PARAMETER) != null) {
+            setAccumulateContent(true);
+        } else {
+            this.tagHandler.beginElement(context);
+        }
+    }
+
+    @Override
+    protected void end(TagContext context)
+    {
+        if (context.getTagStack().getStackParameter(IN_CONFLUENCE_PARAMETER) != null) {
+            MacroTagHandler.ConfluenceMacro macro =
+                (MacroTagHandler.ConfluenceMacro) context.getTagStack().getStackParameter(CONFLUENCE_CONTAINER);
+
+            if (macro != null) {
+                WikiParameter href = context.getParams().getParameter("href");
+                WikiParameter name = context.getParent().getParams().getParameter("ac:name");
+                if (href != null && name != null) {
+                    macro.parameters = macro.parameters.addParameter(name.getValue(), href.getValue());
+                }
+            }
+        } else {
+            this.tagHandler.endElement(context);
+        }
+    }
+}

--- a/confluence-syntax-xhtml/src/test/resources/confluence+xhtml10/specific/macro/macro7.test
+++ b/confluence-syntax-xhtml/src/test/resources/confluence+xhtml10/specific/macro/macro7.test
@@ -1,0 +1,20 @@
+.#-----------------------------------------------------
+.input|confluence+xhtml/1.0
+.# CONFLUENCE-105: URL macro parameter value is not imported in XWiki.
+.#-----------------------------------------------------
+<ac:structured-macro ac:name="macroName">
+    <ac:parameter ac:name="linkParam">
+        <a href="https://www.bing.com/images/search?q=icon">
+            https://www.bing.com/images/search?q=icon</a>
+    </ac:parameter>
+    <ac:parameter ac:name="otherParam">ParamValue</ac:parameter>
+    <ac:rich-text-body>
+        <p>Macro content <b>Helloo</b></p>
+    </ac:rich-text-body>
+</ac:structured-macro>
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+onMacroStandalone [macroName] [linkParam=https://www.bing.com/images/search?q=icon|otherParam=ParamValue] [Macro content Helloo]
+endDocument

--- a/confluence-xml/src/test/resources/confluencexml/links.test
+++ b/confluence-xml/src/test/resources/confluencexml/links.test
@@ -44,7 +44,11 @@
 
 [[link>>doc:xwiki:OK.NgszKw||shape="rect"]]
 
-[[link>>doc:xwiki:OK.SRwC||shape="rect"]]</string>
+[[link>>doc:xwiki:OK.SRwC||shape="rect"]]
+
+{{lozenge icon="https://icon-library.com/images/img_524932.png" link="https://www.bing.com/images/search?q=icon" width="auto"}}
+Some content
+{{/lozenge}}</string>
             </entry>
             <entry>
               <string>syntax</string>

--- a/confluence-xml/src/test/resources/confluencexml/links/entities.xml
+++ b/confluence-xml/src/test/resources/confluencexml/links/entities.xml
@@ -70,6 +70,20 @@
         <p><a href="https://confluence.atlassian.com/x/liAC">link</a></p>
         <p><a href="https://confluence.atlassian.com/x/NgszKw">link</a></p>
         <p><a href="https://confluence.atlassian.com/x/SRwC">link</a></p>
+        <p>
+        <ac:structured-macro ac:name="lozenge" ac:schema-version="1"
+          ac:macro-id="40373a62-b942-4525-b8d1-3771615f053a">
+          <ac:parameter ac:name="icon">https://icon-library.com/images/img_524932.png</ac:parameter>
+          <ac:parameter ac:name="link">
+            <a href="https://www.bing.com/images/search?q=icon">
+              https://www.bing.com/images/search?q=icon</a>
+            </ac:parameter>
+          <ac:parameter ac:name="width">auto</ac:parameter>
+          <ac:rich-text-body>
+            <p>Some content</p>
+          </ac:rich-text-body>
+          </ac:structured-macro>
+        </p>
       ]]>
     </property>
     <property name="content" class="Page" package="com.atlassian.confluence.pages">

--- a/confluence-xml/src/test/resources/confluencexml/rootspace.test
+++ b/confluence-xml/src/test/resources/confluencexml/rootspace.test
@@ -46,7 +46,11 @@
 
 [[link>>url:https://confluence.atlassian.com/x/NgszKw||shape="rect"]]
 
-[[link>>url:https://confluence.atlassian.com/x/SRwC||shape="rect"]]</string>
+[[link>>url:https://confluence.atlassian.com/x/SRwC||shape="rect"]]
+
+{{lozenge icon="https://icon-library.com/images/img_524932.png" link="https://www.bing.com/images/search?q=icon" width="auto"}}
+Some content
+{{/lozenge}}</string>
                 </entry>
                 <entry>
                   <string>syntax</string>


### PR DESCRIPTION
…rameter

Wrapped the default reference handler and handled the case where an **a** tag is a child of a confluence macro param tag.

Closes https://jira.xwiki.org/browse/CONFLUENCE-290