### PR TITLE
CONFLUENCE-392: Annotations are not really imported as annotations

### DIFF
--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/ConfluenceXHTMLParser.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/ConfluenceXHTMLParser.java
@@ -54,6 +54,8 @@ import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.AttachmentTa
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.CaptionHandler;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.CodeTagHandler;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.ConfluenceAttributeXMLFilter;
+import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.ConfluenceImgTagHandler;
+import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.ConfluenceInlineCommentTagHandler;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.ConfluenceListItemTagHandler;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.ConfluenceOrderedListTagHandler;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.ConfluenceParagraphTagHandler;
@@ -67,7 +69,6 @@ import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.FallbackConf
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.FallbackConfluenceURLConverter;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.IgnoredTagHandler;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.ImageTagHandler;
-import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.ConfluenceImgTagHandler;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.LinkBodyTagHandler;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.LinkTagHandler;
 import org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel.MacroParameterTagHandler;
@@ -266,6 +267,8 @@ public class ConfluenceXHTMLParser extends AbstractWikiModelParser
         handlers.put("ac:adf-attribute", new ADFAttributeHandler());
         handlers.put("ac:adf-content", new ADFContentHandler(this));
         handlers.put("ac:adf-mark", new ADFMarkHandler());
+
+        handlers.put("ac:inline-comment-marker", new ConfluenceInlineCommentTagHandler());
 
         parser.setExtraHandlers(handlers);
 

--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/ConfluenceInlineCommentTagHandler.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/ConfluenceInlineCommentTagHandler.java
@@ -1,0 +1,47 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel;
+
+import org.xwiki.rendering.wikimodel.xhtml.handler.AbstractFormatTagHandler;
+
+/**
+ * Handles inline comments. The goal is not so much to convert it to some XWiki equivalent but to make easier to extract
+ * them from the content.
+ * <p>
+ * {@code
+ * 
+<p>
+ * Before
+ * <ac:inline-comment-marker ac:ref="21641e47-9393-4d3c-890f-0994b2181443">annotated content</ac:inline-comment-marker>
+ * after.
+ * 
+</p>
+ * }
+ * 
+ * @version $Id$
+ * @since 9.79.0
+ */
+public class ConfluenceInlineCommentTagHandler extends AbstractFormatTagHandler
+{
+    /**
+     * The name of the parameter holding the reference of the inline comment.
+     */
+    public static final String PARAMETER_REF = "ac:ref";
+}

--- a/confluence-syntax-xhtml/src/test/resources/confluence+xhtml10/specific/annotation/annotation.test
+++ b/confluence-syntax-xhtml/src/test/resources/confluence+xhtml10/specific/annotation/annotation.test
@@ -1,0 +1,16 @@
+.#-----------------------------------------------------
+.input|confluence+xhtml/1.0
+.#-----------------------------------------------------
+<p>before<ac:inline-comment-marker ac:ref="21641e47-9393-4d3c-890f-0994b2181443">annotation</ac:inline-comment-marker>after</p>
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+beginParagraph
+onWord [before]
+beginFormat [NONE] [[ac:ref]=[21641e47-9393-4d3c-890f-0994b2181443]]
+onWord [annotation]
+endFormat [NONE] [[ac:ref]=[21641e47-9393-4d3c-890f-0994b2181443]]
+onWord [after]
+endParagraph
+endDocument

--- a/confluence-xml/pom.xml
+++ b/confluence-xml/pom.xml
@@ -117,6 +117,12 @@
       <artifactId>xwiki-rendering-syntax-xwiki21</artifactId>
       <version>${rendering.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-annotation-core</artifactId>
+      <version>${platform.version}</version>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.xwiki.commons</groupId>

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/input/ConfluenceXMLPackage.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/input/ConfluenceXMLPackage.java
@@ -211,6 +211,13 @@ public class ConfluenceXMLPackage implements AutoCloseable
     public static final String KEY_LABELLING_CONTENT = KEY_CONTENT;
 
     /**
+     * The property key to access the object content properties.
+     * 
+     * @since 9.79.0
+     */
+    public static final String KEY_CONTENTPROPERTIES = "contentProperties";
+
+    /**
      * The property key to access the space permission username.
      * @since 9.24.0
      */
@@ -383,14 +390,20 @@ public class ConfluenceXMLPackage implements AutoCloseable
 
     /**
      * The property key to access the attachment content properties.
+     * 
+     * @deprecated since 9.79.0, use {@link #KEY_CONTENTPROPERTIES} instead
      */
-    public static final String KEY_ATTACHMENT_CONTENTPROPERTIES = "contentProperties";
+    @Deprecated
+    public static final String KEY_ATTACHMENT_CONTENTPROPERTIES = KEY_CONTENTPROPERTIES;
 
     /**
      * The property key to access the comment content key.
+     * 
      * @since 9.72.0
+     * @deprecated since 9.79.0, use {@link #KEY_CONTENTPROPERTIES} instead
      */
-    public static final String KEY_COMMENT_CONTENTPROPERTIES = KEY_ATTACHMENT_CONTENTPROPERTIES;
+    @Deprecated
+    public static final String KEY_COMMENT_CONTENTPROPERTIES = KEY_CONTENTPROPERTIES;
 
     /**
      * The property key to access the attachment content status.
@@ -921,7 +934,7 @@ public class ConfluenceXMLPackage implements AutoCloseable
 
     /**
      * @param source the source where to find the package to parse
-     * @param workingDirectory the directory to use to extract the conflence package for processing (can be null)
+     * @param workingDirectory the directory to use to extract the confluence package for processing (can be null)
      * @throws IOException when failing to access the package content
      * @throws FilterException when any error happen during the reading of the package
      * @since 9.37.0

--- a/confluence-xml/src/test/resources/confluencexml/annotations.test
+++ b/confluence-xml/src/test/resources/confluencexml/annotations.test
@@ -1,0 +1,108 @@
+.#------------------------------------------------------------------------------
+.expect|filter+xml
+.#------------------------------------------------------------------------------
+<wikiSpace name="Annotation">
+  <wikiDocument name="WebHome">
+    <wikiDocumentLocale>
+      <p>
+        <parameters>
+          <entry>
+            <string>creation_author</string>
+            <string>XWiki.8a7f80897523097801753189db971e45</string>
+          </entry>
+          <entry>
+            <string>creation_date</string>
+            <date>2025-02-10 14:32:09.233 UTC</date>
+          </entry>
+          <entry>
+            <string>lastrevision</string>
+            <string>2</string>
+          </entry>
+        </parameters>
+      </p>
+      <wikiDocumentRevision revision="2">
+        <p>
+          <parameters>
+            <entry>
+              <string>revision_author</string>
+              <string>XWiki.8a7f80897523097801753189db971e45</string>
+            </entry>
+            <entry>
+              <string>revision_date</string>
+              <date>2025-02-10 14:33:22.946 UTC</date>
+            </entry>
+            <entry>
+              <string>revision_comment</string>
+              <string>
+    </string>
+            </entry>
+            <entry>
+              <string>title</string>
+              <string>Annotations</string>
+            </entry>
+            <entry>
+              <string>content</string>
+              <string>before annotation after
+
+Other paragraph.</string>
+            </entry>
+            <entry>
+              <string>syntax</string>
+              <org.xwiki.rendering.syntax.Syntax>
+                <type>
+                  <name>XWiki</name>
+                  <id>xwiki</id>
+                  <variants class="empty-list"/>
+                </type>
+                <version>2.1</version>
+              </org.xwiki.rendering.syntax.Syntax>
+            </entry>
+          </parameters>
+        </p>
+        <wikiObject name="XWiki.XWikiComments">
+          <p>
+            <parameters>
+              <entry>
+                <string>class_reference</string>
+                <string>XWiki.XWikiComments</string>
+              </entry>
+            </parameters>
+          </p>
+          <wikiObjectProperty name="author" value="XWiki.8a7f80897523097801753189db971e45"/>
+          <wikiObjectProperty name="comment" value="annotation 1"/>
+          <wikiObjectProperty name="date">
+            <p>
+              <value t="java.util.Date">2025-02-10 14:33:37.774 UTC</value>
+            </p>
+          </wikiObjectProperty>
+          <wikiObjectProperty name="replyto"/>
+          <wikiObjectProperty name="selection" value="annotation"/>
+        </wikiObject>
+        <wikiObject name="XWiki.XWikiComments">
+          <p>
+            <parameters>
+              <entry>
+                <string>class_reference</string>
+                <string>XWiki.XWikiComments</string>
+              </entry>
+            </parameters>
+          </p>
+          <wikiObjectProperty name="author" value="XWiki.8a7f80897523097801753189db971e45"/>
+          <wikiObjectProperty name="comment" value="annotation 2"/>
+          <wikiObjectProperty name="date">
+            <p>
+              <value t="java.util.Date">2025-02-10 14:33:49.425 UTC</value>
+            </p>
+          </wikiObjectProperty>
+          <wikiObjectProperty name="replyto"/>
+          <wikiObjectProperty name="selection" value="Other paragraph."/>
+        </wikiObject>
+      </wikiDocumentRevision>
+    </wikiDocumentLocale>
+  </wikiDocument>
+</wikiSpace>
+.#------------------------------------------------------------------------------
+.input|confluence+xml
+.configuration.storeConfluenceDetailsEnabled=false
+.configuration.source=annotations
+.#------------------------------------------------------------------------------

--- a/confluence-xml/src/test/resources/confluencexml/annotations/entities.xml
+++ b/confluence-xml/src/test/resources/confluencexml/annotations/entities.xml
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hibernate-generic datetime="2025-02-10 14:35:30.208">
+  <object class="Space" package="com.atlassian.confluence.spaces">
+    <id name="id">949321732</id>
+    <property name="name"><![CDATA[Annotations]]></property>
+    <property name="key"><![CDATA[Annotation]]></property>
+    <property name="lowerKey"><![CDATA[annotation]]></property>
+    <property name="homePage" class="Page" package="com.atlassian.confluence.pages">
+      <id name="id">949323637</id>
+    </property>
+    <property name="creator" class="ConfluenceUserImpl" package="com.atlassian.confluence.user">
+      <id name="key"><![CDATA[8a7f80897523097801753189db971e45]]></id>
+    </property>
+    <property name="creationDate">2025-02-10 14:32:05.836</property>
+    <property name="lastModifier" class="ConfluenceUserImpl" package="com.atlassian.confluence.user">
+      <id name="key"><![CDATA[8a7f80897523097801753189db971e45]]></id>
+    </property>
+    <property name="lastModificationDate">2025-02-10 14:32:09.239</property>
+    <property name="spaceType">collaboration</property>
+    <property name="spaceStatus" enum-class="SpaceStatus" package="com.atlassian.confluence.spaces">CURRENT</property>
+  </object>
+
+  <object class="Page" package="com.atlassian.confluence.pages">
+    <id name="id">949323637</id>
+    <property name="hibernateVersion">13</property>
+    <property name="title"><![CDATA[Annotations]]></property>
+    <property name="lowerTitle"><![CDATA[annotations]]></property>
+    <collection name="bodyContents"
+      class="java.util.Collection(com.atlassian.confluence.core.ContentEntityObject.bodyContents)">
+      <element class="BodyContent" package="com.atlassian.confluence.core">
+        <id name="id">949323638</id>
+      </element>
+    </collection>
+    <collection name="adfContentBodies"
+      class="java.util.Collection(com.atlassian.confluence.core.ContentEntityObject.adfContentBodies)"></collection>
+    <collection name="contentProperties"
+      class="java.util.Collection(com.atlassian.confluence.core.ContentEntityObject.contentProperties)">
+      <element class="ContentProperty" package="com.atlassian.confluence.content">
+        <id name="id">949323697</id>
+      </element>
+      <element class="ContentProperty" package="com.atlassian.confluence.content">
+        <id name="id">949323698</id>
+      </element>
+      <element class="ContentProperty" package="com.atlassian.confluence.content">
+        <id name="id">949747721</id>
+      </element>
+      <element class="ContentProperty" package="com.atlassian.confluence.content">
+        <id name="id">949387267</id>
+      </element>
+      <element class="ContentProperty" package="com.atlassian.confluence.content">
+        <id name="id">949387268</id>
+      </element>
+    </collection>
+    <property name="version">2</property>
+    <property name="creator" class="ConfluenceUserImpl" package="com.atlassian.confluence.user">
+      <id name="key"><![CDATA[8a7f80897523097801753189db971e45]]></id>
+    </property>
+    <property name="creationDate">2025-02-10 14:32:09.233</property>
+    <property name="lastModifier" class="ConfluenceUserImpl" package="com.atlassian.confluence.user">
+      <id name="key"><![CDATA[8a7f80897523097801753189db971e45]]></id>
+    </property>
+    <property name="lastModificationDate">2025-02-10 14:33:22.946</property>
+    <property name="versionComment"><![CDATA[]]>
+    </property>
+    <property name="contentStatus"><![CDATA[current]]></property>
+    <property name="navigationType">1</property>
+    <collection name="comments"
+      class="java.util.Set(com.atlassian.confluence.core.ContentEntityObject.comments)">
+      <element class="Comment" package="com.atlassian.confluence.pages">
+        <id name="id">949846020</id>
+      </element>
+      <element class="Comment" package="com.atlassian.confluence.pages">
+        <id name="id">949878785</id>
+      </element>
+    </collection>
+    <property name="space" class="Space" package="com.atlassian.confluence.spaces">
+      <id name="id">949321732</id>
+    </property>
+  </object>
+
+  <object class="Comment" package="com.atlassian.confluence.pages">
+    <id name="id">949846020</id>
+    <property name="hibernateVersion">3</property>
+    <property name="title" />
+    <property name="lowerTitle" />
+    <collection name="bodyContents"
+      class="java.util.Collection(com.atlassian.confluence.core.ContentEntityObject.bodyContents)">
+      <element class="BodyContent" package="com.atlassian.confluence.core">
+        <id name="id">949846021</id>
+      </element>
+    </collection>
+    <collection name="contentProperties"
+      class="java.util.Collection(com.atlassian.confluence.core.ContentEntityObject.contentProperties)">
+      <element class="ContentProperty" package="com.atlassian.confluence.content">
+        <id name="id">949846022</id>
+      </element>
+      <element class="ContentProperty" package="com.atlassian.confluence.content">
+        <id name="id">949846023</id>
+      </element>
+      <element class="ContentProperty" package="com.atlassian.confluence.content">
+        <id name="id">949846024</id>
+      </element>
+      <element class="ContentProperty" package="com.atlassian.confluence.content">
+        <id name="id">949846025</id>
+      </element>
+      <element class="ContentProperty" package="com.atlassian.confluence.content">
+        <id name="id">949846026</id>
+      </element>
+      <element class="ContentProperty" package="com.atlassian.confluence.content">
+        <id name="id">949846027</id>
+      </element>
+    </collection>
+    <property name="version">1</property>
+    <property name="creator" class="ConfluenceUserImpl" package="com.atlassian.confluence.user">
+      <id name="key"><![CDATA[8a7f80897523097801753189db971e45]]></id>
+    </property>
+    <property name="creationDate">2025-02-10 14:33:37.774</property>
+    <property name="lastModifier" class="ConfluenceUserImpl" package="com.atlassian.confluence.user">
+      <id name="key"><![CDATA[8a7f80897523097801753189db971e45]]></id>
+    </property>
+    <property name="lastModificationDate">2025-02-10 14:33:37.774</property>
+    <property name="versionComment"><![CDATA[]]>
+    </property>
+    <property name="originalVersionId" />
+    <property name="contentStatus"><![CDATA[current]]></property>
+    <property name="navigationType">0</property>
+    <property name="containerContent" class="Page" package="com.atlassian.confluence.pages">
+      <id name="id">949323637</id>
+    </property>
+  </object>
+
+  <object class="ContentProperty" package="com.atlassian.confluence.content">
+    <id name="id">949846022</id>
+    <property name="name"><![CDATA[comment-uuid]]></property>
+    <property name="stringValue"><![CDATA[44fdbea7-d5f2-4344-925a-75ffc5284bcd]]></property>
+    <property name="longValue" />
+    <property name="dateValue" />
+  </object>
+  <object class="ContentProperty" package="com.atlassian.confluence.content">
+    <id name="id">949846023</id>
+    <property name="name"><![CDATA[actualCommentType]]></property>
+    <property name="stringValue"><![CDATA[inline]]></property>
+    <property name="longValue" />
+    <property name="dateValue" />
+  </object>
+  <object class="ContentProperty" package="com.atlassian.confluence.content">
+    <id name="id">949846024</id>
+    <property name="name"><![CDATA[inline-marker-ref]]></property>
+    <property name="stringValue"><![CDATA[21641e47-9393-4d3c-890f-0994b2181443]]></property>
+    <property name="longValue" />
+    <property name="dateValue" />
+  </object>
+  <object class="ContentProperty" package="com.atlassian.confluence.content">
+    <id name="id">949846025</id>
+    <property name="name"><![CDATA[inline-comment]]></property>
+    <property name="stringValue"><![CDATA[true]]></property>
+    <property name="longValue" />
+    <property name="dateValue" />
+  </object>
+  <object class="ContentProperty" package="com.atlassian.confluence.content">
+    <id name="id">949846026</id>
+    <property name="name"><![CDATA[inline-original-selection]]></property>
+    <property name="stringValue"><![CDATA[, consectetur adipiscing elit. M]]></property>
+    <property name="longValue" />
+    <property name="dateValue" />
+  </object>
+  <object class="ContentProperty" package="com.atlassian.confluence.content">
+    <id name="id">949846027</id>
+    <property name="name"><![CDATA[macroNames]]></property>
+    <property name="stringValue"><![CDATA[]]>
+    </property>
+    <property name="longValue" />
+    <property name="dateValue" />
+  </object>
+
+  <object class="BodyContent" package="com.atlassian.confluence.core">
+    <id name="id">949323638</id>
+    <property name="body"><![CDATA[<p>before <ac:inline-comment-marker ac:ref="21641e47-9393-4d3c-890f-0994b2181443">annotation </ac:inline-comment-marker>after</p><p><ac:inline-comment-marker ac:ref="12a4f118-df1b-4071-b36d-cc387f062b41">Other paragraph.</ac:inline-comment-marker></p>]]></property>
+    <property name="content" class="Page" package="com.atlassian.confluence.pages">
+      <id name="id">949323637</id>
+    </property>
+    <property name="bodyType">2</property>
+  </object>
+
+  <object class="BodyContent" package="com.atlassian.confluence.core">
+    <id name="id">949846021</id>
+    <property name="body"><![CDATA[<p>annotation 1</p>]]></property>
+    <property name="content" class="Comment" package="com.atlassian.confluence.pages">
+      <id name="id">949846020</id>
+    </property>
+    <property name="bodyType">2</property>
+  </object>
+
+  <object class="BodyContent" package="com.atlassian.confluence.core">
+    <id name="id">949878786</id>
+    <property name="body"><![CDATA[<p>annotation 2</p>]]></property>
+    <property name="content" class="Comment" package="com.atlassian.confluence.pages">
+      <id name="id">949878785</id>
+    </property>
+    <property name="bodyType">2</property>
+  </object>
+
+  <object class="Comment" package="com.atlassian.confluence.pages">
+    <id name="id">949878785</id>
+    <property name="hibernateVersion">3</property>
+    <property name="title" />
+    <property name="lowerTitle" />
+    <collection name="bodyContents"
+      class="java.util.Collection(com.atlassian.confluence.core.ContentEntityObject.bodyContents)">
+      <element class="BodyContent" package="com.atlassian.confluence.core">
+        <id name="id">949878786</id>
+      </element>
+    </collection>
+    <collection name="contentProperties"
+      class="java.util.Collection(com.atlassian.confluence.core.ContentEntityObject.contentProperties)">
+      <element class="ContentProperty" package="com.atlassian.confluence.content">
+        <id name="id">949878787</id>
+      </element>
+      <element class="ContentProperty" package="com.atlassian.confluence.content">
+        <id name="id">949878788</id>
+      </element>
+      <element class="ContentProperty" package="com.atlassian.confluence.content">
+        <id name="id">949878789</id>
+      </element>
+      <element class="ContentProperty" package="com.atlassian.confluence.content">
+        <id name="id">949878790</id>
+      </element>
+      <element class="ContentProperty" package="com.atlassian.confluence.content">
+        <id name="id">949878791</id>
+      </element>
+      <element class="ContentProperty" package="com.atlassian.confluence.content">
+        <id name="id">949878792</id>
+      </element>
+    </collection>
+    <property name="version">1</property>
+    <property name="creator" class="ConfluenceUserImpl" package="com.atlassian.confluence.user">
+      <id name="key"><![CDATA[8a7f80897523097801753189db971e45]]></id>
+    </property>
+    <property name="creationDate">2025-02-10 14:33:49.425</property>
+    <property name="lastModifier" class="ConfluenceUserImpl" package="com.atlassian.confluence.user">
+      <id name="key"><![CDATA[8a7f80897523097801753189db971e45]]></id>
+    </property>
+    <property name="lastModificationDate">2025-02-10 14:33:49.425</property>
+    <property name="versionComment"><![CDATA[]]>
+    </property>
+    <property name="originalVersionId" />
+    <property name="contentStatus"><![CDATA[current]]></property>
+    <property name="navigationType">0</property>
+    <property name="containerContent" class="Page" package="com.atlassian.confluence.pages">
+      <id name="id">949323637</id>
+    </property>
+  </object>
+
+  <object class="ContentProperty" package="com.atlassian.confluence.content">
+    <id name="id">949878787</id>
+    <property name="name"><![CDATA[comment-uuid]]></property>
+    <property name="stringValue"><![CDATA[a8bdc798-c637-4f09-8393-5331d527e0e8]]></property>
+    <property name="longValue" />
+    <property name="dateValue" />
+  </object>
+  <object class="ContentProperty" package="com.atlassian.confluence.content">
+    <id name="id">949878788</id>
+    <property name="name"><![CDATA[actualCommentType]]></property>
+    <property name="stringValue"><![CDATA[inline]]></property>
+    <property name="longValue" />
+    <property name="dateValue" />
+  </object>
+  <object class="ContentProperty" package="com.atlassian.confluence.content">
+    <id name="id">949878789</id>
+    <property name="name"><![CDATA[inline-marker-ref]]></property>
+    <property name="stringValue"><![CDATA[12a4f118-df1b-4071-b36d-cc387f062b41]]></property>
+    <property name="longValue" />
+    <property name="dateValue" />
+  </object>
+  <object class="ContentProperty" package="com.atlassian.confluence.content">
+    <id name="id">949878790</id>
+    <property name="name"><![CDATA[inline-comment]]></property>
+    <property name="stringValue"><![CDATA[true]]></property>
+    <property name="longValue" />
+    <property name="dateValue" />
+  </object>
+  <object class="ContentProperty" package="com.atlassian.confluence.content">
+    <id name="id">949878791</id>
+    <property name="name"><![CDATA[inline-original-selection]]></property>
+    <property name="stringValue"><![CDATA[Sed sollicitudin, turpis sit amet lacinia euismod, quam orci tincidunt metus, ut finibus nibh lectus vel nulla. Sed tincidunt tellus magna, eget commodo nisl ullamcorper aliquam. Maecenas aliquam, tellus ac varius efficitur, justo sapien pharetra orci,...]]></property>
+    <property name="longValue" />
+    <property name="dateValue" />
+  </object>
+  <object class="ContentProperty" package="com.atlassian.confluence.content">
+    <id name="id">949878792</id>
+    <property name="name"><![CDATA[macroNames]]></property>
+    <property name="stringValue"><![CDATA[]]>
+    </property>
+    <property name="longValue" />
+    <property name="dateValue" />
+  </object>
+
+</hibernate-generic>

--- a/confluence-xml/src/test/resources/confluencexml/inlinecomments.test
+++ b/confluence-xml/src/test/resources/confluencexml/inlinecomments.test
@@ -183,6 +183,7 @@ Line 8
               </p>
             </wikiObjectProperty>
             <wikiObjectProperty name="replyto"/>
+            <wikiObjectProperty name="selection" value="Line 2"/>
           </wikiObject>
           <wikiObject name="XWiki.XWikiComments">
             <p>
@@ -245,6 +246,7 @@ Line 8
               </p>
             </wikiObjectProperty>
             <wikiObjectProperty name="replyto"/>
+            <wikiObjectProperty name="selection" value="Line 4"/>
           </wikiObject>
           <wikiObject name="XWiki.XWikiComments">
             <p>


### PR DESCRIPTION
* let annotation marker go through in the syntax parser
* catch and clean annotated content in the filter
* add a clean annotated content in the comment object selection field