### PR TITLE
CONFLUENCE-413: Add a converter for Jira chart

### DIFF
--- a/confluence-xml/checkstyle-suppressions.xml
+++ b/confluence-xml/checkstyle-suppressions.xml
@@ -15,4 +15,6 @@
             files="src/main/java/org/xwiki/contrib/confluence/filter/internal/input/ConfluenceConverterListener\.java$"/>
   <suppress checks="CyclomaticComplexity"
             files="src/main/java/org/xwiki/contrib/confluence/filter/internal/idrange/ConfluenceIdRange\.java$"/>
+  <suppress checks="CyclomaticComplexity|JavaNCSS|ExecutableStatementCount"
+            files="src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/JiraChartMacroConverter\.java$"/>
 </suppressions>

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/JiraChartMacroConverter.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/JiraChartMacroConverter.java
@@ -1,0 +1,158 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.contrib.confluence.filter.internal.macros;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+
+/**
+ * Convert Confluence jira chart macro.
+ *
+ * @version $Id$
+ * @since 9.81.0
+ */
+@Component
+@Singleton
+@Named("jirachart")
+public class JiraChartMacroConverter extends AbstractMacroConverter
+{
+    private static final Map<String, String> VERSION_LABEL_MAP = Map.of(
+        "all", "ALL",
+        "major", "ONLY_MAJOR",
+        "none", "NONE"
+    );
+
+    private static final Pattern JQL_FILTER_PATTERN = Pattern.compile("^filter\\s*=\\s*(\\d+)$");
+
+    private static final String CUSTOM = "CUSTOM";
+
+    private static final String FALSE = "false";
+
+    private static final String TRUE = "true";
+
+    private static final String PARAM_CHART_TYPE = "chartType";
+
+    @Override
+    public String toXWikiId(String confluenceId, Map<String, String> confluenceParameters, String confluenceContent,
+        boolean inline)
+    {
+        String type = confluenceParameters.get(PARAM_CHART_TYPE);
+        switch (type) {
+            case "pie":
+                return "jiraPieChart";
+            case "createdvsresolved":
+                return "jiraCreatedVsResolvedChart";
+            case "twodimensional":
+                return "jiraBiDimensionalGridChart";
+            default:
+                return confluenceId;
+        }
+    }
+
+    @Override
+    protected Map<String, String> toXWikiParameters(String confluenceId, Map<String, String> confluenceParameters,
+        String content)
+    {
+        Map<String, String> parameters = new LinkedHashMap<>(confluenceParameters.size());
+
+        for (Map.Entry<String, String> entry : confluenceParameters.entrySet()) {
+            String name = entry.getKey();
+            String confluenceValue = entry.getValue();
+            String xwikiValue = toXWikiParameterValue(name, confluenceValue, confluenceId, parameters, content);
+
+            switch (name) {
+                // Parameter used for all charts
+                case PARAM_CHART_TYPE:
+                    // Not needed as in XWiki we have a specific macro for each type
+                    break;
+                case "server":
+                    parameters.put("id", xwikiValue);
+                    break;
+                case "jql":
+                    xwikiValue = URLDecoder.decode(xwikiValue, StandardCharsets.UTF_8);
+                    Matcher jqlFilterMatcher = JQL_FILTER_PATTERN.matcher(xwikiValue);
+                    if (jqlFilterMatcher.find()) {
+                        String filterId = "filter-" + jqlFilterMatcher.group(1);
+                        parameters.put("filterId", filterId);
+                    } else {
+                        parameters.put("query", xwikiValue);
+                    }
+                    break;
+
+                // Pie chart related parameters
+                case "statType":
+                    parameters.put("type", xwikiValue);
+                    break;
+
+                // CreatedVsResolved chart related parameters
+                case "daysprevious":
+                    parameters.put("daysPreviously", xwikiValue);
+                    break;
+                case "periodName":
+                    parameters.put("period", xwikiValue.toUpperCase());
+                    break;
+                case "isCumulative":
+                    // Need to inverse the boolean
+                    String boolValue = TRUE.equalsIgnoreCase(xwikiValue) ? FALSE : TRUE;
+                    parameters.put("count", boolValue);
+                    break;
+                case "showUnresolvedTrend":
+                    parameters.put("displayTrend", xwikiValue);
+                    break;
+                case "versionLabel":
+                    xwikiValue = VERSION_LABEL_MAP.getOrDefault(xwikiValue, xwikiValue);
+                    parameters.put("displayVersion", xwikiValue);
+                    break;
+
+                // Bi Dimensional Grid chart related parameters
+                case "xstattype":
+                    parameters.put("xAxisField", xwikiValue);
+                    break;
+                case "ystattype":
+                    parameters.put("yAxisField", xwikiValue);
+                    break;
+                case "numberToShow":
+                    parameters.put("numberOfResults", xwikiValue);
+                    break;
+
+                default:
+                    String parameterName = toXWikiParameterName(name, confluenceId, parameters, content);
+                    parameters.put(parameterName, xwikiValue);
+                    break;
+            }
+        }
+        return parameters;
+    }
+
+    @Override
+    public InlineSupport supportsInlineMode(String id, Map<String, String> parameters, String content)
+    {
+        return InlineSupport.NO;
+    }
+}

--- a/confluence-xml/src/main/resources/META-INF/components.txt
+++ b/confluence-xml/src/main/resources/META-INF/components.txt
@@ -21,6 +21,7 @@ org.xwiki.contrib.confluence.filter.internal.macros.DefaultMacroConverter
 org.xwiki.contrib.confluence.filter.internal.macros.IncludeMacroConverter
 org.xwiki.contrib.confluence.filter.internal.macros.ImgMacroConverter
 org.xwiki.contrib.confluence.filter.internal.macros.LivesearchMacroConverter
+org.xwiki.contrib.confluence.filter.internal.macros.JiraChartMacroConverter
 org.xwiki.contrib.confluence.filter.internal.macros.JiraMacroConverter
 org.xwiki.contrib.confluence.filter.internal.macros.MacroToContentConverter
 org.xwiki.contrib.confluence.filter.internal.macros.MathblockRefMacroConverter

--- a/confluence-xml/src/test/resources/confluencexml/jirachart.test
+++ b/confluence-xml/src/test/resources/confluencexml/jirachart.test
@@ -1,0 +1,108 @@
+.#------------------------------------------------------------------------------
+.expect|filter+xml
+.# Content conversions
+.#------------------------------------------------------------------------------
+<wikiSpace name="MySpace">
+  <wikiDocument name="WebHome">
+    <wikiDocumentLocale>
+      <p>
+        <parameters>
+          <entry>
+            <string>creation_author</string>
+            <string>XWiki.01f7c1cc638e0d8c0163d05ca6f60124</string>
+          </entry>
+          <entry>
+            <string>creation_date</string>
+            <date>2019-02-13 08:05:54.0 UTC</date>
+          </entry>
+          <entry>
+            <string>lastrevision</string>
+            <string>1</string>
+          </entry>
+        </parameters>
+      </p>
+      <wikiDocumentRevision revision="1">
+        <p>
+          <parameters>
+            <entry>
+              <string>revision_author</string>
+              <string>XWiki.01f7c1cc638e0d8c0163d05ca6f60124</string>
+            </entry>
+            <entry>
+              <string>revision_date</string>
+              <date>2019-02-13 08:16:56.0 UTC</date>
+            </entry>
+            <entry>
+              <string>revision_comment</string>
+              <string></string>
+            </entry>
+            <entry>
+              <string>title</string>
+              <string>My Space</string>
+            </entry>
+            <entry>
+              <string>content</string>
+              <string>Pie chart
+
+
+
+{{jiraPieChart border="false" showinfor="false" id="JIRA Dev" query="project = ~"Hello Word Toto for It~" " type="components" isAuthenticated="true" serverId="a60d537f-6941-4483-872e-913674cb30f4"/}}
+
+
+
+{{jiraPieChart border="true" showinfor="true" id="JIRA server ID" query="project = ~"Hello Word Toto for It~" " type="priorities" width="300" isAuthenticated="true" serverId="a60d537f-6941-4483-872e-913674cb30f4"/}}
+
+
+
+{{jiraPieChart border="false" showinfor="false" id="JIRA server ID" filterId="filter-20847" type="customfield_12234" serverId="a60d537f-6941-4483-872e-913674cb30f4"/}}
+
+
+
+{{jiraPieChart border="false" showinfor="false" id="JIRA server ID" filterId="filter-20847" type="reporter" serverId="a60d537f-6941-4483-872e-913674cb30f4"/}}
+
+CreatedVsResolved chart
+
+
+
+{{jiraCreatedVsResolvedChart border="false" id="JIRA server ID" query="project = ABCDX" period="DAILY" displayTrend="false" isAuthenticated="true" serverId="a60d537f-6941-4483-872e-913674cb30f4" showinfor="false" displayVersion="ALL" count="true" daysPreviously="300"/}}
+
+
+
+{{jiraCreatedVsResolvedChart border="true" id="JIRA server ID" query="project = ABCDX" period="WEEKLY" displayTrend="true" isAuthenticated="true" serverId="a60d537f-6941-4483-872e-913674cb30f4" showinfor="true" displayVersion="ONLY_MAJOR" count="false" width="400" daysPreviously="10"/}}
+
+
+
+{{jiraCreatedVsResolvedChart border="true" id="JIRA server ID" query="project = ABCDX" period="WEEKLY" displayTrend="true" isAuthenticated="true" serverId="a60d537f-6941-4483-872e-913674cb30f4" showinfor="true" displayVersion="NONE" count="false" width="400" daysPreviously="30"/}}
+
+BiDimensionalGrid chart
+
+
+
+{{jiraBiDimensionalGridChart id="JIRA server ID" query="filter = ~"MY YELLOW CAR~"" yAxisField="assignees" isAuthenticated="true" numberOfResults="5" xAxisField="statuses" serverId="a60d537f-6941-4483-872e-913674cb30f4"/}}
+
+
+
+{{jiraBiDimensionalGridChart id="JIRA server ID" filterId="filter-12341" yAxisField="customfield_13500" isAuthenticated="true" numberOfResults="20" xAxisField="customfield_14700" serverId="a60d537f-6941-4483-872e-913674cb30f4"/}}</string>
+            </entry>
+            <entry>
+              <string>syntax</string>
+              <org.xwiki.rendering.syntax.Syntax>
+                <type>
+                  <name>XWiki</name>
+                  <id>xwiki</id>
+                  <variants class="empty-list"/>
+                </type>
+                <version>2.1</version>
+              </org.xwiki.rendering.syntax.Syntax>
+            </entry>
+          </parameters>
+        </p>
+      </wikiDocumentRevision>
+    </wikiDocumentLocale>
+  </wikiDocument>
+</wikiSpace>
+.#------------------------------------------------------------------------------
+.input|confluence+xml
+.configuration.source=jirachart
+.configuration.storeConfluenceDetailsEnabled=false
+.#------------------------------------------------------------------------------

--- a/confluence-xml/src/test/resources/confluencexml/jirachart/entities.xml
+++ b/confluence-xml/src/test/resources/confluencexml/jirachart/entities.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hibernate-generic>
+  <object class="Space" package="com.atlassian.confluence.spaces">
+    <id name="id">46268417</id>
+    <property name="name"><![CDATA[My Space]]></property>
+    <property name="key"><![CDATA[MySpace]]></property>
+    <property name="lowerKey"><![CDATA[myspace]]></property>
+    <property name="homePage" class="Page" package="com.atlassian.confluence.pages">
+      <id name="id">45809846</id>
+    </property>
+    <collection name="permissions" class="java.util.Collection"/>
+    <property name="creator" class="ConfluenceUserImpl" package="com.atlassian.confluence.user">
+      <id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+    </property>
+    <property name="creationDate">2012-08-21 15:37:47.000</property>
+    <property name="lastModifier" class="ConfluenceUserImpl" package="com.atlassian.confluence.user">
+      <id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+    </property>
+    <property name="lastModificationDate">2016-10-11 14:47:37.000</property>
+    <property name="spaceType">global</property>
+    <property name="spaceStatus" enum-class="SpaceStatus" package="com.atlassian.confluence.spaces">CURRENT</property>
+  </object>
+  <object class="BodyContent" package="com.atlassian.confluence.core">
+    <id name="id">156868656</id>
+    <property name="body"><![CDATA[
+<p>Pie chart</p>
+  <p><ac:structured-macro ac:name="jirachart" ac:schema-version="1" ac:macro-id="b6c8cf9a-526d-40ab-b921-d0a0e1cf93d7">
+    <ac:parameter ac:name="border">false</ac:parameter>
+    <ac:parameter ac:name="showinfor">false</ac:parameter>
+    <ac:parameter ac:name="server">JIRA Dev</ac:parameter>
+    <ac:parameter ac:name="jql">project%20%3D%20%22Hello%20Word%20Toto%20for%20It%22%20</ac:parameter>
+    <ac:parameter ac:name="statType">components</ac:parameter>
+    <ac:parameter ac:name="chartType">pie</ac:parameter>
+    <ac:parameter ac:name="width" /><ac:parameter ac:name="isAuthenticated">true</ac:parameter>
+    <ac:parameter ac:name="serverId">a60d537f-6941-4483-872e-913674cb30f4</ac:parameter>
+  </ac:structured-macro></p>
+  <p><ac:structured-macro ac:name="jirachart" ac:schema-version="1" ac:macro-id="27381ce3-50a7-48a6-b0e4-5af9658232d9">
+    <ac:parameter ac:name="border">true</ac:parameter>
+    <ac:parameter ac:name="showinfor">true</ac:parameter>
+    <ac:parameter ac:name="server">JIRA server ID</ac:parameter>
+    <ac:parameter ac:name="jql">project%20%3D%20%22Hello%20Word%20Toto%20for%20It%22%20</ac:parameter>
+    <ac:parameter ac:name="statType">priorities</ac:parameter>
+    <ac:parameter ac:name="chartType">pie</ac:parameter>
+    <ac:parameter ac:name="width">300</ac:parameter>
+    <ac:parameter ac:name="isAuthenticated">true</ac:parameter>
+    <ac:parameter ac:name="serverId">a60d537f-6941-4483-872e-913674cb30f4</ac:parameter>
+  </ac:structured-macro></p>
+  <p><ac:structured-macro ac:name="jirachart" ac:schema-version="1" ac:macro-id="27381ce3-50a7-48a6-b0e4-5af9658232d9">
+    <ac:parameter ac:name="border">false</ac:parameter>
+    <ac:parameter ac:name="showinfor">false</ac:parameter>
+    <ac:parameter ac:name="server">JIRA server ID</ac:parameter>
+    <ac:parameter ac:name="jql">filter%3D20847</ac:parameter>
+    <ac:parameter ac:name="statType">customfield_12234</ac:parameter>
+    <ac:parameter ac:name="chartType">pie</ac:parameter>
+    <ac:parameter ac:name="serverId">a60d537f-6941-4483-872e-913674cb30f4</ac:parameter>
+  </ac:structured-macro></p>
+  <p><ac:structured-macro ac:name="jirachart" ac:schema-version="1" ac:macro-id="27381ce3-50a7-48a6-b0e4-5af9658232d9">
+    <ac:parameter ac:name="border">false</ac:parameter>
+    <ac:parameter ac:name="showinfor">false</ac:parameter>
+    <ac:parameter ac:name="server">JIRA server ID</ac:parameter>
+    <ac:parameter ac:name="jql">filter%3D20847</ac:parameter>
+    <ac:parameter ac:name="statType">reporter</ac:parameter>
+    <ac:parameter ac:name="chartType">pie</ac:parameter>
+    <ac:parameter ac:name="serverId">a60d537f-6941-4483-872e-913674cb30f4</ac:parameter>
+  </ac:structured-macro></p>
+
+  <p>CreatedVsResolved chart</p>
+  <p><ac:structured-macro ac:name="jirachart" ac:schema-version="1" ac:macro-id="41613da8-6c65-4369-901a-95d214d6edc5">
+    <ac:parameter ac:name="border">false</ac:parameter>
+    <ac:parameter ac:name="server">JIRA server ID</ac:parameter>
+    <ac:parameter ac:name="jql">project%20%3D%20ABCDX</ac:parameter>
+    <ac:parameter ac:name="periodName">daily</ac:parameter>
+    <ac:parameter ac:name="showUnresolvedTrend">false</ac:parameter>
+    <ac:parameter ac:name="isAuthenticated">true</ac:parameter>
+    <ac:parameter ac:name="serverId">a60d537f-6941-4483-872e-913674cb30f4</ac:parameter>
+    <ac:parameter ac:name="showinfor">false</ac:parameter>
+    <ac:parameter ac:name="versionLabel">all</ac:parameter>
+    <ac:parameter ac:name="isCumulative">false</ac:parameter>
+    <ac:parameter ac:name="chartType">createdvsresolved</ac:parameter>
+    <ac:parameter ac:name="width" />
+    <ac:parameter ac:name="daysprevious">300</ac:parameter>
+  </ac:structured-macro></p>
+  <p><ac:structured-macro ac:name="jirachart" ac:schema-version="1" ac:macro-id="ef9e8af2-7bc7-47ee-b4f0-94f92703a68d">
+    <ac:parameter ac:name="border">true</ac:parameter>
+    <ac:parameter ac:name="server">JIRA server ID</ac:parameter>
+    <ac:parameter ac:name="jql">project%20%3D%20ABCDX</ac:parameter>
+    <ac:parameter ac:name="periodName">weekly</ac:parameter>
+    <ac:parameter ac:name="showUnresolvedTrend">true</ac:parameter>
+    <ac:parameter ac:name="isAuthenticated">true</ac:parameter>
+    <ac:parameter ac:name="serverId">a60d537f-6941-4483-872e-913674cb30f4</ac:parameter>
+    <ac:parameter ac:name="showinfor">true</ac:parameter>
+    <ac:parameter ac:name="versionLabel">major</ac:parameter>
+    <ac:parameter ac:name="isCumulative">true</ac:parameter>
+    <ac:parameter ac:name="chartType">createdvsresolved</ac:parameter>
+    <ac:parameter ac:name="width">400</ac:parameter>
+    <ac:parameter ac:name="daysprevious">10</ac:parameter>
+  </ac:structured-macro></p>
+  <p><ac:structured-macro ac:name="jirachart" ac:schema-version="1" ac:macro-id="ef9e8af2-7bc7-47ee-b4f0-94f92703a68d">
+    <ac:parameter ac:name="border">true</ac:parameter>
+    <ac:parameter ac:name="server">JIRA server ID</ac:parameter>
+    <ac:parameter ac:name="jql">project%20%3D%20ABCDX</ac:parameter>
+    <ac:parameter ac:name="periodName">weekly</ac:parameter>
+    <ac:parameter ac:name="showUnresolvedTrend">true</ac:parameter>
+    <ac:parameter ac:name="isAuthenticated">true</ac:parameter>
+    <ac:parameter ac:name="serverId">a60d537f-6941-4483-872e-913674cb30f4</ac:parameter>
+    <ac:parameter ac:name="showinfor">true</ac:parameter>
+    <ac:parameter ac:name="versionLabel">none</ac:parameter>
+    <ac:parameter ac:name="isCumulative">true</ac:parameter>
+    <ac:parameter ac:name="chartType">createdvsresolved</ac:parameter>
+    <ac:parameter ac:name="width">400</ac:parameter>
+    <ac:parameter ac:name="daysprevious">30</ac:parameter>
+  </ac:structured-macro></p>
+
+  <p>BiDimensionalGrid chart</p>
+  <p><ac:structured-macro ac:name="jirachart" ac:schema-version="1" ac:macro-id="8d49e50f-b383-40c0-bd05-956097adabea">
+    <ac:parameter ac:name="server">JIRA server ID</ac:parameter>
+    <ac:parameter ac:name="sortDirection" />
+    <ac:parameter ac:name="jql">filter%20%3D%20%22MY%20YELLOW%20CAR%22</ac:parameter>
+    <ac:parameter ac:name="ystattype">assignees</ac:parameter>
+    <ac:parameter ac:name="chartType">twodimensional</ac:parameter>
+    <ac:parameter ac:name="width" /><ac:parameter ac:name="sortBy" />
+    <ac:parameter ac:name="isAuthenticated">true</ac:parameter>
+    <ac:parameter ac:name="numberToShow">5</ac:parameter>
+    <ac:parameter ac:name="xstattype">statuses</ac:parameter>
+    <ac:parameter ac:name="serverId">a60d537f-6941-4483-872e-913674cb30f4</ac:parameter>
+  </ac:structured-macro></p>
+  <p><ac:structured-macro ac:name="jirachart" ac:schema-version="1" ac:macro-id="2f9fdff7-295f-494b-963f-bf50b3e21d71">
+    <ac:parameter ac:name="server">JIRA server ID</ac:parameter>
+    <ac:parameter ac:name="sortDirection" />
+    <ac:parameter ac:name="jql">filter%20%3D%2012341</ac:parameter>
+    <ac:parameter ac:name="ystattype">customfield_13500</ac:parameter>
+    <ac:parameter ac:name="chartType">twodimensional</ac:parameter>
+    <ac:parameter ac:name="width" /><ac:parameter ac:name="sortBy" />
+    <ac:parameter ac:name="isAuthenticated">true</ac:parameter>
+    <ac:parameter ac:name="numberToShow">20</ac:parameter>
+    <ac:parameter ac:name="xstattype">customfield_14700</ac:parameter>
+    <ac:parameter ac:name="serverId">a60d537f-6941-4483-872e-913674cb30f4</ac:parameter>
+  </ac:structured-macro></p>
+]]></property>
+    <property name="content" class="Page" package="com.atlassian.confluence.pages">
+      <id name="id">45809846</id>
+    </property>
+    <property name="bodyType">2</property>
+  </object>
+  <object class="Page" package="com.atlassian.confluence.pages">
+    <id name="id">45809846</id>
+    <property name="hibernateVersion">13</property>
+    <property name="title"><![CDATA[Links]]></property>
+    <property name="lowerTitle"><![CDATA[links]]></property>
+    <collection name="bodyContents" class="java.util.Collection">
+      <element class="BodyContent" package="com.atlassian.confluence.core">
+        <id name="id">156868656</id>
+      </element>
+    </collection>
+    <property name="version">1</property>
+    <property name="creator" class="ConfluenceUserImpl" package="com.atlassian.confluence.user">
+      <id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+    </property>
+    <property name="creationDate">2019-02-13 08:05:54.000</property>
+    <property name="lastModifier" class="ConfluenceUserImpl" package="com.atlassian.confluence.user">
+      <id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+    </property>
+    <property name="lastModificationDate">2019-02-13 08:16:56.000</property>
+    <property name="versionComment"><![CDATA[]]></property>
+    <property name="contentStatus"><![CDATA[current]]></property>
+    <property name="space" class="Space" package="com.atlassian.confluence.spaces">
+      <id name="id">46268417</id>
+    </property>
+    <property name="position"/>
+  </object>
+</hibernate-generic>


### PR DESCRIPTION
Jira issue: https://jira.xwiki.org/browse/CONFLUENCE-413

For now it's a draft because:
- I need to do more test to validate that with real data the conversion work correctly and the XWiki has the same result than the confluence version.
- I'm waiting on a fix on these following issue to be sure that the converter will generate a macro compatible with the next jira version:
  - https://jira.xwiki.org/browse/JIRA-72
  - https://jira.xwiki.org/browse/JIRA-71
  - https://jira.xwiki.org/browse/JIRA-68
  - https://jira.xwiki.org/browse/JIRA-73
  - https://jira.xwiki.org/browse/JIRA-74