### PR TITLE
CONFLUENCE-417: Provide a converter for the link-group and center macros

### DIFF
--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/CenterMacroConverter.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/CenterMacroConverter.java
@@ -19,12 +19,14 @@
  */
 package org.xwiki.contrib.confluence.filter.internal.macros;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
+import org.xwiki.contrib.confluence.filter.MacroConverter;
 
 /**
  * Convert Confluence center macro.
@@ -37,11 +39,27 @@ import org.xwiki.component.annotation.Component;
 @Named("center")
 public class CenterMacroConverter extends AbstractMacroConverter
 {
+    private static final String CLASS = "class";
+
     @Override
     public String toXWikiId(String confluenceId, Map<String, String> confluenceParameters, String confluenceContent,
         boolean inline)
     {
-        markHandledParameter(confluenceParameters, "class", true);
         return "center";
+    }
+
+    @Override
+    protected Map<String, String> toXWikiParameters(String confluenceId, Map<String, String> confluenceParameters,
+        String content)
+    {
+        Map<String, String> parameters = new HashMap<>(1);
+        parameters.put(CLASS, confluenceParameters.get(CLASS));
+        return parameters;
+    }
+
+    @Override
+    public MacroConverter.InlineSupport supportsInlineMode(String id, Map<String, String> parameters, String content)
+    {
+        return MacroConverter.InlineSupport.NO;
     }
 }

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/CenterMacroConverter.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/CenterMacroConverter.java
@@ -1,0 +1,47 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.contrib.confluence.filter.internal.macros;
+
+import java.util.Map;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+
+/**
+ * Convert Confluence center macro.
+ *
+ * @version $Id$
+ * @since 9.82
+ */
+@Component
+@Singleton
+@Named("center")
+public class CenterMacroConverter extends AbstractMacroConverter
+{
+    @Override
+    public String toXWikiId(String confluenceId, Map<String, String> confluenceParameters, String confluenceContent,
+        boolean inline)
+    {
+        markHandledParameter(confluenceParameters, "class", true);
+        return "center";
+    }
+}

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/ClickableMacroConverter.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/ClickableMacroConverter.java
@@ -57,6 +57,8 @@ public class ClickableMacroConverter extends AbstractMacroConverter
     @Override
     public InlineSupport supportsInlineMode(String id, Map<String, String> parameters, String content)
     {
-        return InlineSupport.NO;
+        return "INLINE".equals(parameters.get("atlassian-macro-output-type"))
+            ? InlineSupport.YES
+            : InlineSupport.MAYBE;
     }
 }

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/ClickableMacroConverter.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/ClickableMacroConverter.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.contrib.confluence.filter.internal.macros;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.inject.Named;
@@ -45,12 +46,17 @@ public class ClickableMacroConverter extends AbstractMacroConverter
     }
 
     @Override
-    protected String toXWikiParameterName(String confluenceParameterName, String id,
-        Map<String, String> confluenceParameters, String confluenceContent)
+    protected Map<String, String> toXWikiParameters(String confluenceId, Map<String, String> confluenceParameters,
+        String content)
     {
-        if ("link".equals(confluenceParameterName)) {
-            return "reference";
-        }
-        return super.toXWikiParameterName(confluenceParameterName, id, confluenceParameters, confluenceContent);
+        Map<String, String> parameters = new HashMap<>(1);
+        parameters.put("reference", confluenceParameters.get("link"));
+        return parameters;
+    }
+
+    @Override
+    public InlineSupport supportsInlineMode(String id, Map<String, String> parameters, String content)
+    {
+        return InlineSupport.NO;
     }
 }

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/ClickableMacroConverter.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/ClickableMacroConverter.java
@@ -1,0 +1,56 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.contrib.confluence.filter.internal.macros;
+
+import java.util.Map;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+
+/**
+ * Convert Confluence clickable macro.
+ *
+ * @version $Id$
+ * @since 9.82
+ */
+@Component
+@Singleton
+@Named("clickable")
+public class ClickableMacroConverter extends AbstractMacroConverter
+{
+    @Override
+    public String toXWikiId(String confluenceId, Map<String, String> confluenceParameters, String confluenceContent,
+        boolean inline)
+    {
+        return "link-group";
+    }
+
+    @Override
+    protected String toXWikiParameterName(String confluenceParameterName, String id,
+        Map<String, String> confluenceParameters, String confluenceContent)
+    {
+        if ("link".equals(confluenceParameterName)) {
+            return "reference";
+        }
+        return super.toXWikiParameterName(confluenceParameterName, id, confluenceParameters, confluenceContent);
+    }
+}

--- a/confluence-xml/src/main/resources/META-INF/components.txt
+++ b/confluence-xml/src/main/resources/META-INF/components.txt
@@ -15,8 +15,10 @@ org.xwiki.contrib.confluence.filter.internal.macros.AlertMacroConverter
 org.xwiki.contrib.confluence.filter.internal.macros.AnchorMacroConverter
 org.xwiki.contrib.confluence.filter.internal.macros.AUIMessageConverter
 org.xwiki.contrib.confluence.filter.internal.macros.BlogPostsMacroConverter
+org.xwiki.contrib.confluence.filter.internal.macros.CenterMacroConverter
 org.xwiki.contrib.confluence.filter.internal.macros.CodeMacroConverter
 org.xwiki.contrib.confluence.filter.internal.macros.ChildrenMacroConverter
+org.xwiki.contrib.confluence.filter.internal.macros.ClickableMacroConverter
 org.xwiki.contrib.confluence.filter.internal.macros.ConditionalContentMacroConverter
 org.xwiki.contrib.confluence.filter.internal.macros.DefaultMacroConverter
 org.xwiki.contrib.confluence.filter.internal.macros.IncludeMacroConverter

--- a/confluence-xml/src/test/resources/confluencexml/center.test
+++ b/confluence-xml/src/test/resources/confluencexml/center.test
@@ -1,0 +1,70 @@
+.#------------------------------------------------------------------------------
+.expect|filter+xml
+.# Test that ascii char 28 is ignored
+.#------------------------------------------------------------------------------
+<wikiSpace name="MySpace">
+  <wikiDocument name="WebHome">
+    <wikiDocumentLocale>
+      <p>
+        <parameters>
+          <entry>
+            <string>creation_author</string>
+            <string>XWiki.Teo</string>
+          </entry>
+          <entry>
+            <string>creation_date</string>
+            <date>2012-08-21 15:37:47.0 UTC</date>
+          </entry>
+          <entry>
+            <string>lastrevision</string>
+            <string>1</string>
+          </entry>
+        </parameters>
+      </p>
+      <wikiDocumentRevision revision="1">
+        <p>
+          <parameters>
+            <entry>
+              <string>revision_author</string>
+              <string>XWiki.Teo</string>
+            </entry>
+            <entry>
+              <string>revision_date</string>
+              <date>2016-10-11 14:47:37.0 UTC</date>
+            </entry>
+            <entry>
+              <string>revision_comment</string>
+              <string></string>
+            </entry>
+            <entry>
+              <string>title</string>
+              <string>My Space</string>
+            </entry>
+            <entry>
+              <string>content</string>
+              <string>{{center class="custom-css"}}
+my centered text
+{{/center}}</string>
+            </entry>
+            <entry>
+              <string>syntax</string>
+              <org.xwiki.rendering.syntax.Syntax>
+                <type>
+                  <name>XWiki</name>
+                  <id>xwiki</id>
+                  <variants class="empty-list"/>
+                </type>
+                <version>2.1</version>
+              </org.xwiki.rendering.syntax.Syntax>
+            </entry>
+          </parameters>
+        </p>
+      </wikiDocumentRevision>
+    </wikiDocumentLocale>
+  </wikiDocument>
+</wikiSpace>
+.#------------------------------------------------------------------------------
+.input|confluence+xml
+.configuration.storeConfluenceDetailsEnabled=false
+.configuration.source=center
+.#------------------------------------------------------------------------------

--- a/confluence-xml/src/test/resources/confluencexml/center/entities.xml
+++ b/confluence-xml/src/test/resources/confluencexml/center/entities.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hibernate-generic datetime="2023-10-02 11:40:11">
+  <object class="ConfluenceUserImpl" package="com.atlassian.confluence.user">
+    <id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+    <property name="name"><![CDATA[Teo]]></property>
+    <property name="lowerName"><![CDATA[Smecherus]]></property>
+    <property name="email"><![CDATA[teo@email.com]]></property>
+  </object>
+  <object class="Page" package="com.atlassian.confluence.spaces">
+    <id name="id">45809845</id>
+    <property name="hibernateVersion">5</property>
+    <property name="title">My Space Home</property>
+    <property name="lowerTitle">my space home</property>
+    <collection name="bodyContents" class="java.util.Collection"><element class="BodyContent" package="com.atlassian.confluence.core"><id name="id">156868656</id>
+    </element>
+    </collection>
+    <property name="version">1</property>
+    <property name="creator" class="ConfluenceUserImpl" package="com.atlassian.confluence.user"><id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+    </property>
+    <property name="creationDate">2012-08-21 15:37:47.000</property>
+    <property name="lastModifier" class="ConfluenceUserImpl" package="com.atlassian.confluence.user"><id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+    </property>
+    <property name="lastModificationDate">2016-10-11 14:47:37.000</property>
+    <property name="versionComment"><![CDATA[]]></property>
+    <property name="contentStatus"><![CDATA[current]]></property>
+    <collection name="labellings" class="java.util.Collection"></collection>
+    <property name="space" class="Space" package="com.atlassian.confluence.spaces"><id name="id">46268417</id>
+    </property>
+    <collection name="attachments" class="java.util.Collection(com.atlassian.confluence.core.ContentEntityObject.attachments)"><element class="Attachment" package="com.atlassian.confluence.pages"><id name="id">134204920</id></element></collection>
+  </object>
+  <object class="Space" package="com.atlassian.confluence.spaces">
+    <id name="id">46268417</id>
+    <property name="name"><![CDATA[My Space]]></property>
+    <property name="key"><![CDATA[MySpace]]></property>
+    <property name="lowerKey"><![CDATA[myspace]]></property>
+    <property name="homePage" class="Page" package="com.atlassian.confluence.pages"><id name="id">45809845</id></property>
+    <collection name="permissions" class="java.util.Collection"></collection>
+    <property name="creator" class="ConfluenceUserImpl" package="com.atlassian.confluence.user"><id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+    </property>
+    <property name="creationDate">2012-08-21 15:37:47.000</property>
+    <property name="lastModifier" class="ConfluenceUserImpl" package="com.atlassian.confluence.user"><id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+    </property>
+    <property name="lastModificationDate">2016-10-11 14:47:37.000</property>
+    <property name="spaceType">global</property>
+    <property name="spaceStatus" enum-class="SpaceStatus" package="com.atlassian.confluence.spaces">CURRENT</property>
+  </object>
+  <object class="BodyContent" package="com.atlassian.confluence.core">
+    <id name="id">156868656</id>
+    <property name="body"><![CDATA[
+<ac:structured-macro ac:name="center" ac:schema-version="1" ac:macro-id="74ab16b0-12dc-4b2b-8785-eb7f51a66cfd">
+  <ac:parameter ac:name="class">custom-css</ac:parameter>
+  <ac:rich-text-body>
+    <p>my centered text</p>
+  </ac:rich-text-body>
+</ac:structured-macro>
+]]></property>
+    <property name="content" class="Page" package="com.atlassian.confluence.pages"><id name="id">45809845</id></property>
+    <property name="bodyType">2</property>
+  </object>
+</hibernate-generic>

--- a/confluence-xml/src/test/resources/confluencexml/clickable.test
+++ b/confluence-xml/src/test/resources/confluencexml/clickable.test
@@ -42,14 +42,14 @@
             </entry>
             <entry>
               <string>content</string>
-              <string>{{link-group reference="confluencePage:page:PANDA.ABCD" atlassian-macro-output-type="INLINE"}}
+              <string>{{link-group reference="confluencePage:page:PANDA.ABCD"}}
 * a
 * b
 
 c
 {{/link-group}}
 
-{{link-group reference="https://xwiki.com" atlassian-macro-output-type="INLINE"}}
+{{link-group reference="https://xwiki.com"}}
 link to xwiki.com
 {{/link-group}}</string>
             </entry>

--- a/confluence-xml/src/test/resources/confluencexml/clickable.test
+++ b/confluence-xml/src/test/resources/confluencexml/clickable.test
@@ -1,0 +1,77 @@
+.#------------------------------------------------------------------------------
+.expect|filter+xml
+.# Test that ascii char 28 is ignored
+.#------------------------------------------------------------------------------
+<wikiSpace name="MySpace">
+  <wikiDocument name="WebHome">
+    <wikiDocumentLocale>
+      <p>
+        <parameters>
+          <entry>
+            <string>creation_author</string>
+            <string>XWiki.Teo</string>
+          </entry>
+          <entry>
+            <string>creation_date</string>
+            <date>2012-08-21 15:37:47.0 UTC</date>
+          </entry>
+          <entry>
+            <string>lastrevision</string>
+            <string>1</string>
+          </entry>
+        </parameters>
+      </p>
+      <wikiDocumentRevision revision="1">
+        <p>
+          <parameters>
+            <entry>
+              <string>revision_author</string>
+              <string>XWiki.Teo</string>
+            </entry>
+            <entry>
+              <string>revision_date</string>
+              <date>2016-10-11 14:47:37.0 UTC</date>
+            </entry>
+            <entry>
+              <string>revision_comment</string>
+              <string></string>
+            </entry>
+            <entry>
+              <string>title</string>
+              <string>My Space</string>
+            </entry>
+            <entry>
+              <string>content</string>
+              <string>{{link-group reference="confluencePage:page:PANDA.ABCD" atlassian-macro-output-type="INLINE"}}
+* a
+* b
+
+c
+{{/link-group}}
+
+{{link-group reference="https://xwiki.com" atlassian-macro-output-type="INLINE"}}
+link to xwiki.com
+{{/link-group}}</string>
+            </entry>
+            <entry>
+              <string>syntax</string>
+              <org.xwiki.rendering.syntax.Syntax>
+                <type>
+                  <name>XWiki</name>
+                  <id>xwiki</id>
+                  <variants class="empty-list"/>
+                </type>
+                <version>2.1</version>
+              </org.xwiki.rendering.syntax.Syntax>
+            </entry>
+          </parameters>
+        </p>
+      </wikiDocumentRevision>
+    </wikiDocumentLocale>
+  </wikiDocument>
+</wikiSpace>
+.#------------------------------------------------------------------------------
+.input|confluence+xml
+.configuration.storeConfluenceDetailsEnabled=false
+.configuration.source=clickable
+.#------------------------------------------------------------------------------

--- a/confluence-xml/src/test/resources/confluencexml/clickable.test
+++ b/confluence-xml/src/test/resources/confluencexml/clickable.test
@@ -51,7 +51,17 @@ c
 
 {{link-group reference="https://xwiki.com"}}
 link to xwiki.com
-{{/link-group}}</string>
+{{/link-group}}
+
+inline
+
+{{link-group reference="https://xwiki.com"}}
+clickable text
+{{/link-group}}
+
+end
+
+inline {{link-group reference="https://xwiki.com"}}clickable text{{/link-group}}end</string>
             </entry>
             <entry>
               <string>syntax</string>

--- a/confluence-xml/src/test/resources/confluencexml/clickable/entities.xml
+++ b/confluence-xml/src/test/resources/confluencexml/clickable/entities.xml
@@ -71,6 +71,22 @@
     <p>link to xwiki.com</p>
   </ac:rich-text-body>
 </ac:structured-macro>
+<!-- Test inline code from confluence even if it won't really work as expected -->
+<p>inline</p>
+<ac:structured-macro ac:name="clickable" ac:schema-version="1" ac:macro-id="4071e9d9-2ce4-4b60-9367-a53e13f8a3fa">
+  <ac:parameter ac:name="link"><a href="https://xwiki.com">https://xwiki.com</a></ac:parameter>
+  <ac:parameter ac:name="atlassian-macro-output-type">INLINE</ac:parameter>
+  <ac:rich-text-body><p>clickable text</p></ac:rich-text-body>
+</ac:structured-macro>
+<p>end</p>
+<!-- An other inline code which don't come from confluence but is expected to work correctly -->
+<p>inline
+<ac:structured-macro ac:name="clickable" ac:schema-version="1" ac:macro-id="4071e9d9-2ce4-4b60-9367-a53e13f8a3fa">
+  <ac:parameter ac:name="link"><a href="https://xwiki.com">https://xwiki.com</a></ac:parameter>
+  <ac:parameter ac:name="atlassian-macro-output-type">INLINE</ac:parameter>
+  <ac:rich-text-body><p>clickable text</p></ac:rich-text-body>
+</ac:structured-macro>
+end</p>
 ]]></property>
     <property name="content" class="Page" package="com.atlassian.confluence.pages"><id name="id">45809845</id></property>
     <property name="bodyType">2</property>

--- a/confluence-xml/src/test/resources/confluencexml/clickable/entities.xml
+++ b/confluence-xml/src/test/resources/confluencexml/clickable/entities.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hibernate-generic datetime="2023-10-02 11:40:11">
+  <object class="ConfluenceUserImpl" package="com.atlassian.confluence.user">
+    <id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+    <property name="name"><![CDATA[Teo]]></property>
+    <property name="lowerName"><![CDATA[Smecherus]]></property>
+    <property name="email"><![CDATA[teo@email.com]]></property>
+  </object>
+  <object class="Page" package="com.atlassian.confluence.spaces">
+    <id name="id">45809845</id>
+    <property name="hibernateVersion">5</property>
+    <property name="title">My Space Home</property>
+    <property name="lowerTitle">my space home</property>
+    <collection name="bodyContents" class="java.util.Collection"><element class="BodyContent" package="com.atlassian.confluence.core"><id name="id">156868656</id>
+    </element>
+    </collection>
+    <property name="version">1</property>
+    <property name="creator" class="ConfluenceUserImpl" package="com.atlassian.confluence.user"><id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+    </property>
+    <property name="creationDate">2012-08-21 15:37:47.000</property>
+    <property name="lastModifier" class="ConfluenceUserImpl" package="com.atlassian.confluence.user"><id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+    </property>
+    <property name="lastModificationDate">2016-10-11 14:47:37.000</property>
+    <property name="versionComment"><![CDATA[]]></property>
+    <property name="contentStatus"><![CDATA[current]]></property>
+    <collection name="labellings" class="java.util.Collection"></collection>
+    <property name="space" class="Space" package="com.atlassian.confluence.spaces"><id name="id">46268417</id>
+    </property>
+    <collection name="attachments" class="java.util.Collection(com.atlassian.confluence.core.ContentEntityObject.attachments)"><element class="Attachment" package="com.atlassian.confluence.pages"><id name="id">134204920</id></element></collection>
+  </object>
+  <object class="Space" package="com.atlassian.confluence.spaces">
+    <id name="id">46268417</id>
+    <property name="name"><![CDATA[My Space]]></property>
+    <property name="key"><![CDATA[MySpace]]></property>
+    <property name="lowerKey"><![CDATA[myspace]]></property>
+    <property name="homePage" class="Page" package="com.atlassian.confluence.pages"><id name="id">45809845</id></property>
+    <collection name="permissions" class="java.util.Collection"></collection>
+    <property name="creator" class="ConfluenceUserImpl" package="com.atlassian.confluence.user"><id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+    </property>
+    <property name="creationDate">2012-08-21 15:37:47.000</property>
+    <property name="lastModifier" class="ConfluenceUserImpl" package="com.atlassian.confluence.user"><id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+    </property>
+    <property name="lastModificationDate">2016-10-11 14:47:37.000</property>
+    <property name="spaceType">global</property>
+    <property name="spaceStatus" enum-class="SpaceStatus" package="com.atlassian.confluence.spaces">CURRENT</property>
+  </object>
+  <object class="BodyContent" package="com.atlassian.confluence.core">
+    <id name="id">156868656</id>
+    <property name="body"><![CDATA[
+<ac:structured-macro ac:name="clickable" ac:schema-version="1" ac:macro-id="0f9a162e-c75c-45f7-ab75-4ea8010f6cbc">
+  <ac:parameter ac:name="link">
+    <ac:link>
+      <ri:page ri:space-key="PANDA" ri:content-title="ABCD"/>
+    </ac:link>
+  </ac:parameter>
+  <ac:parameter ac:name="atlassian-macro-output-type">INLINE</ac:parameter>
+  <ac:rich-text-body>
+    <ul>
+      <li>a</li>
+      <li>b</li>
+    </ul>
+    <p>c</p>
+  </ac:rich-text-body>
+</ac:structured-macro>
+<ac:structured-macro ac:name="clickable" ac:schema-version="1" ac:macro-id="4739aa94-8770-43f4-bca0-c9532323ce24">
+  <ac:parameter ac:name="link">
+    <a href="https://xwiki.com">https://xwiki.com</a>
+  </ac:parameter>
+  <ac:parameter ac:name="atlassian-macro-output-type">INLINE</ac:parameter>
+  <ac:rich-text-body>
+    <p>link to xwiki.com</p>
+  </ac:rich-text-body>
+</ac:structured-macro>
+]]></property>
+    <property name="content" class="Page" package="com.atlassian.confluence.pages"><id name="id">45809845</id></property>
+    <property name="bodyType">2</property>
+  </object>
+</hibernate-generic>


### PR DESCRIPTION
# Jira issue

https://jira.xwiki.org/browse/CONFLUENCE-417

Macro implementation:
* https://github.com/xwiki-contrib/link-format/pull/1
* https://github.com/xwiki-contrib/layout/pull/2