### PR TITLE
CONFLUENCE-454: Add a way to keep unhandled or all Confluence macro parameters, prefixed

### DIFF
--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/input/ConfluenceInputProperties.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/input/ConfluenceInputProperties.java
@@ -59,10 +59,11 @@ public class ConfluenceInputProperties extends DefaultFilterStreamProperties
     private static final String XWIKI_ALL_GROUP_NAME = "XWikiAllGroup";
     private static final String CLEANUP_SYNC = "SYNC";
     private static final String WEB_HOME = "WebHome";
+    private static final String CONFLUENCE_UNDERSCORE = "confluence_";
+    private static final String DEFAULT_GROUP_FORMAT = "${group._clean}";
+    private static final String NONE = "NONE";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ConfluenceInputProperties.class);
-
-    private static final String DEFAULT_GROUP_FORMAT = "${group._clean}";
 
     /**
      * @see #getSource()
@@ -132,7 +133,14 @@ public class ConfluenceInputProperties extends DefaultFilterStreamProperties
     /**
      * @see #getUnknownMacroPrefix()
      */
-    private String unknownMacroPrefix = "confluence_";
+    private String unknownMacroPrefix = CONFLUENCE_UNDERSCORE;
+
+    /**
+     * @see #getUnknownMacroPrefix()
+     */
+    private String keptMacroParameterPrefix = CONFLUENCE_UNDERSCORE;
+
+    private String keptMacroParameterMode = NONE;
 
     private Set<String> prefixedMacros;
 
@@ -627,6 +635,58 @@ public class ConfluenceInputProperties extends DefaultFilterStreamProperties
         this.unknownMacroPrefix = unknownMacroPrefix;
     }
 
+    /**
+     * @return the prefix to use in the name of the macros parameters that are kept as-is
+     * @since 9.84.0
+     */
+    @PropertyName("Kept macro parameter prefix")
+    @PropertyDescription("The prefix to use in the name of the macro parameters that are kept as-is "
+        + "(except for atlassian-macro-output-type and for parameters that happen to be already prefixed with this "
+        + "string: those will be kept unprefixed)")
+    public String getKeptMacroParameterPrefix()
+    {
+        return this.keptMacroParameterPrefix;
+    }
+
+    /**
+     * @param keptMacroParameterPrefix the prefix to use in the name of the macros parameters that are kept as-is
+     * @since 9.84.0
+     */
+    public void setKeptMacroParameterPrefix(String keptMacroParameterPrefix)
+    {
+        this.keptMacroParameterPrefix = keptMacroParameterPrefix == null ? "" : keptMacroParameterPrefix;
+    }
+
+    /**
+     * @return the prefix to use in the name of the macros parameters that are kept as-is
+     * @since 9.84.0
+     */
+    @PropertyName("Kept macro parameter mode")
+    @PropertyDescription("Which macro parameter to keep as is with the specified prefix. NONE: don't keep Confluence "
+        + "macro parameters. UNHANDLED: keep macro parameters that are not handled and normally kept during macro "
+        + "conversion. ALL: keep all the parameters, even those ")
+    public String getKeptMacroParameterMode()
+    {
+        return this.keptMacroParameterMode;
+    }
+
+    /**
+     * @param keptMacroParameterMode the prefix to use in the name of the macros parameters that are kept as-is
+     * @since 9.84.0
+     */
+    public void setKeptMacroParameterMode(String keptMacroParameterMode)
+    {
+        String mode = StringUtils.isEmpty(keptMacroParameterMode)
+            ? NONE
+            : keptMacroParameterMode.toUpperCase();
+
+        if (mode.equals("UNHANDLED") || mode.equals("ALL") || mode.equals(NONE)) {
+            this.keptMacroParameterMode = mode;
+        } else {
+            LOGGER.error("Unexpected Kept macro parameter mode [{}], will default to NONE", mode);
+            this.keptMacroParameterMode = NONE;
+        }
+    }
     /**
      * @return the unknown macros for which the name should be prefixed
      * @since 9.8

--- a/confluence-xml/src/test/java/org/xwiki/contrib/confluence/filter/FakeBlockMacroConverter.java
+++ b/confluence-xml/src/test/java/org/xwiki/contrib/confluence/filter/FakeBlockMacroConverter.java
@@ -25,6 +25,7 @@ import org.xwiki.contrib.confluence.filter.internal.macros.AbstractMacroConverte
 import javax.inject.Named;
 import javax.inject.Singleton;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Converts to a block macro.
@@ -44,5 +45,19 @@ public class FakeBlockMacroConverter extends AbstractMacroConverter
             throw new RuntimeException("Crash requested, happy to oblige");
         }
         return "view-file";
+    }
+
+    @Override
+    protected Map<String, String> toXWikiParameters(String confluenceId, Map<String, String> confluenceParameters,
+        String content)
+    {
+        if (confluenceParameters.containsKey("pleasecollide")) {
+            return new TreeMap<>(Map.of(
+                "origpleasecollide", "fromConverter",
+                "randomParam", "42"
+            ));
+        }
+
+        return confluenceParameters;
     }
 }

--- a/confluence-xml/src/test/resources/confluencexml/keptparams/entities.xml
+++ b/confluence-xml/src/test/resources/confluencexml/keptparams/entities.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hibernate-generic datetime="2023-10-02 11:40:11">
+    <object class="ConfluenceUserImpl" package="com.atlassian.confluence.user">
+        <id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+        <property name="name"><![CDATA[47826731]]></property>
+        <property name="lowerName"><![CDATA[47826731]]></property>
+        <property name="email"/>
+    </object>
+    <object class="Page" package="com.atlassian.confluence.spaces">
+        <id name="id">45809845</id>
+        <property name="hibernateVersion">5</property>
+        <property name="title">My Space Home</property>
+        <property name="lowerTitle">my space home</property>
+        <collection name="bodyContents" class="java.util.Collection"><element class="BodyContent" package="com.atlassian.confluence.core"><id name="id">156868656</id>
+        </element>
+        </collection>
+        <property name="version">1</property>
+        <property name="creator" class="ConfluenceUserImpl" package="com.atlassian.confluence.user"><id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+        </property>
+        <property name="creationDate">2012-08-21 15:37:47.000</property>
+        <property name="lastModifier" class="ConfluenceUserImpl" package="com.atlassian.confluence.user"><id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+        </property>
+        <property name="lastModificationDate">2016-10-11 14:47:37.000</property>
+        <property name="versionComment"><![CDATA[]]></property>
+        <property name="contentStatus"><![CDATA[current]]></property>
+        <collection name="labellings" class="java.util.Collection"></collection>
+        <property name="space" class="Space" package="com.atlassian.confluence.spaces"><id name="id">46268417</id>
+        </property>
+        <collection name="attachments" class="java.util.Collection(com.atlassian.confluence.core.ContentEntityObject.attachments)"><element class="Attachment" package="com.atlassian.confluence.pages"><id name="id">134204920</id></element></collection>
+    </object>
+    <object class="Space" package="com.atlassian.confluence.spaces">
+        <id name="id">46268417</id>
+        <property name="name"><![CDATA[My Space]]></property>
+        <property name="key"><![CDATA[MySpace]]></property>
+        <property name="lowerKey"><![CDATA[myspace]]></property>
+        <property name="homePage" class="Page" package="com.atlassian.confluence.pages"><id name="id">45809845</id></property>
+        <collection name="permissions" class="java.util.Collection"></collection>
+        <property name="creator" class="ConfluenceUserImpl" package="com.atlassian.confluence.user"><id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+        </property>
+        <property name="creationDate">2012-08-21 15:37:47.000</property>
+        <property name="lastModifier" class="ConfluenceUserImpl" package="com.atlassian.confluence.user"><id name="key"><![CDATA[01f7c1cc638e0d8c0163d05ca6f60124]]></id>
+        </property>
+        <property name="lastModificationDate">2016-10-11 14:47:37.000</property>
+        <property name="spaceType">global</property>
+        <property name="spaceStatus" enum-class="SpaceStatus" package="com.atlassian.confluence.spaces">CURRENT</property>
+    </object>
+    <object class="BodyContent" package="com.atlassian.confluence.core">
+        <id name="id">156868656</id>
+        <property name="body"><![CDATA[
+            <p><ac:structured-macro ac:name="livesearch">
+                <ac:parameter ac:name="spaceKey"><ri:space ri:space-key="DEMO" /></ac:parameter>
+                <ac:parameter ac:name="size">large</ac:parameter>
+                <ac:parameter ac:name="additional">none</ac:parameter>
+                <ac:parameter ac:name="confluence_fakeparam">yes</ac:parameter>
+                <ac:parameter ac:name="atlassian-macro-output-type">INLINE</ac:parameter>
+            </ac:structured-macro></p>
+            <p><ac:structured-macro ac:name="unsupported-macro-which-converts-to-bridge">
+                <ac:parameter ac:name="spaceKey"><ri:space ri:space-key="DEMO" /></ac:parameter>
+                <ac:parameter ac:name="size">large</ac:parameter>
+                <ac:parameter ac:name="additional">none</ac:parameter>
+                <ac:parameter ac:name="confluence_fakeparam">yes</ac:parameter>
+                <ac:parameter ac:name="atlassian-macro-output-type">INLINE</ac:parameter>
+            </ac:structured-macro></p>
+            <p><ac:structured-macro ac:name="pagetree">
+                <ac:parameter ac:name="root"><ac:link /></ac:parameter>
+                <ac:parameter ac:name="startDepth">3</ac:parameter>
+                <ac:parameter ac:name="searchBox">true</ac:parameter>
+                <ac:parameter ac:name="expandCollapseAll">true</ac:parameter>
+            </ac:structured-macro></p>
+            <p><ac:structured-macro ac:name="convertedtoblock">
+                <ac:parameter ac:name="pleasecollide">yes</ac:parameter>
+                <ac:parameter ac:name="origpleasecollide">fromconfluence</ac:parameter>
+                <ac:parameter ac:name="confluence_whyprefixed">dontknow</ac:parameter>
+                <ac:parameter ac:name="atlassian-macro-output-type">INLINE</ac:parameter>
+            </ac:structured-macro></p>
+            <p><ac:structured-macro ac:name="convertedtoblock">
+                <ac:parameter ac:name="pleasecrash">yes</ac:parameter>
+                <ac:parameter ac:name="pleasecollide">yes</ac:parameter>
+                <ac:parameter ac:name="confluence_pleasecollide">fromconfluence</ac:parameter>
+                <ac:parameter ac:name="confluence_whyprefixed">dontknow</ac:parameter>
+                <ac:parameter ac:name="atlassian-macro-output-type">INLINE</ac:parameter>
+            </ac:structured-macro></p>
+        ]]></property>
+        <property name="content" class="Page" package="com.atlassian.confluence.pages"><id name="id">45809845</id></property>
+        <property name="bodyType">2</property>
+    </object>
+</hibernate-generic>

--- a/confluence-xml/src/test/resources/confluencexml/keptparamsall.test
+++ b/confluence-xml/src/test/resources/confluencexml/keptparamsall.test
@@ -1,0 +1,76 @@
+.#------------------------------------------------------------------------------
+.expect|filter+xml
+.#------------------------------------------------------------------------------
+<wikiSpace name="MySpace">
+  <wikiDocument name="WebHome">
+    <wikiDocumentLocale>
+      <p>
+        <parameters>
+          <entry>
+            <string>creation_author</string>
+            <string>XWiki.47826731</string>
+          </entry>
+          <entry>
+            <string>creation_date</string>
+            <date>2012-08-21 15:37:47.0 UTC</date>
+          </entry>
+          <entry>
+            <string>lastrevision</string>
+            <string>1</string>
+          </entry>
+        </parameters>
+      </p>
+      <wikiDocumentRevision revision="1">
+        <p>
+          <parameters>
+            <entry>
+              <string>revision_author</string>
+              <string>XWiki.47826731</string>
+            </entry>
+            <entry>
+              <string>revision_date</string>
+              <date>2016-10-11 14:47:37.0 UTC</date>
+            </entry>
+            <entry>
+              <string>revision_comment</string>
+              <string></string>
+            </entry>
+            <entry>
+              <string>title</string>
+              <string>My Space</string>
+            </entry>
+            <entry>
+              <string>content</string>
+              <string>{{locationSearch atlassian-macro-output-type="INLINE" confluence_additional="none" confluence_fakeparam="yes" confluence_size="large" confluence_spaceKey="OutsideSpace.DEMO" reference="OutsideSpace.DEMO" showExcerpts="true" width="100%"/}}
+
+{{unsupported-macro-which-converts-to-bridge spaceKey="OutsideSpace.DEMO" size="large" additional="none" confluence_fakeparam="yes" atlassian-macro-output-type="INLINE"/}}
+
+{{documentTree confluence_expandCollapseAll="true" confluence_searchBox="true" confluence_startDepth="3" root="document:WebHome"/}}
+
+{{view-file atlassian-macro-output-type="INLINE" confluence_pleasecollide="yes" confluence_whyprefixed="dontknow" origpleasecollide="fromConverter" randomParam="42"/}}
+
+{{convertedtoblock pleasecrash="yes" pleasecollide="yes" confluence_pleasecollide="fromconfluence" confluence_whyprefixed="dontknow" atlassian-macro-output-type="INLINE"/}}</string>
+            </entry>
+            <entry>
+              <string>syntax</string>
+              <org.xwiki.rendering.syntax.Syntax>
+                <type>
+                  <name>XWiki</name>
+                  <id>xwiki</id>
+                  <variants class="empty-list"/>
+                </type>
+                <version>2.1</version>
+              </org.xwiki.rendering.syntax.Syntax>
+            </entry>
+          </parameters>
+        </p>
+      </wikiDocumentRevision>
+    </wikiDocumentLocale>
+  </wikiDocument>
+</wikiSpace>
+.#------------------------------------------------------------------------------
+.input|confluence+xml
+.configuration.source=keptparams
+.configuration.storeConfluenceDetailsEnabled=false
+.configuration.keptMacroParameterMode=ALL
+.#------------------------------------------------------------------------------

--- a/confluence-xml/src/test/resources/confluencexml/keptparamscollide.test
+++ b/confluence-xml/src/test/resources/confluencexml/keptparamscollide.test
@@ -1,0 +1,77 @@
+.#------------------------------------------------------------------------------
+.expect|filter+xml
+.#------------------------------------------------------------------------------
+<wikiSpace name="MySpace">
+  <wikiDocument name="WebHome">
+    <wikiDocumentLocale>
+      <p>
+        <parameters>
+          <entry>
+            <string>creation_author</string>
+            <string>XWiki.47826731</string>
+          </entry>
+          <entry>
+            <string>creation_date</string>
+            <date>2012-08-21 15:37:47.0 UTC</date>
+          </entry>
+          <entry>
+            <string>lastrevision</string>
+            <string>1</string>
+          </entry>
+        </parameters>
+      </p>
+      <wikiDocumentRevision revision="1">
+        <p>
+          <parameters>
+            <entry>
+              <string>revision_author</string>
+              <string>XWiki.47826731</string>
+            </entry>
+            <entry>
+              <string>revision_date</string>
+              <date>2016-10-11 14:47:37.0 UTC</date>
+            </entry>
+            <entry>
+              <string>revision_comment</string>
+              <string></string>
+            </entry>
+            <entry>
+              <string>title</string>
+              <string>My Space</string>
+            </entry>
+            <entry>
+              <string>content</string>
+              <string>{{locationSearch atlassian-macro-output-type="INLINE" origadditional="none" origconfluence_fakeparam="yes" origsize="large" origspaceKey="OutsideSpace.DEMO" reference="OutsideSpace.DEMO" showExcerpts="true" width="100%"/}}
+
+{{unsupported-macro-which-converts-to-bridge spaceKey="OutsideSpace.DEMO" size="large" additional="none" confluence_fakeparam="yes" atlassian-macro-output-type="INLINE"/}}
+
+{{documentTree origexpandCollapseAll="true" origsearchBox="true" origstartDepth="3" root="document:WebHome"/}}
+
+{{view-file atlassian-macro-output-type="INLINE" origconfluence_whyprefixed="dontknow" origpleasecollide="fromConverter" randomParam="42"/}}
+
+{{convertedtoblock pleasecrash="yes" pleasecollide="yes" confluence_pleasecollide="fromconfluence" confluence_whyprefixed="dontknow" atlassian-macro-output-type="INLINE"/}}</string>
+            </entry>
+            <entry>
+              <string>syntax</string>
+              <org.xwiki.rendering.syntax.Syntax>
+                <type>
+                  <name>XWiki</name>
+                  <id>xwiki</id>
+                  <variants class="empty-list"/>
+                </type>
+                <version>2.1</version>
+              </org.xwiki.rendering.syntax.Syntax>
+            </entry>
+          </parameters>
+        </p>
+      </wikiDocumentRevision>
+    </wikiDocumentLocale>
+  </wikiDocument>
+</wikiSpace>
+.#------------------------------------------------------------------------------
+.input|confluence+xml
+.configuration.source=keptparams
+.configuration.storeConfluenceDetailsEnabled=false
+.configuration.keptMacroParameterMode=ALL
+.configuration.keptMacroParameterPrefix=orig
+.#------------------------------------------------------------------------------

--- a/confluence-xml/src/test/resources/confluencexml/keptparamsnone.test
+++ b/confluence-xml/src/test/resources/confluencexml/keptparamsnone.test
@@ -1,0 +1,76 @@
+.#------------------------------------------------------------------------------
+.expect|filter+xml
+.#------------------------------------------------------------------------------
+<wikiSpace name="MySpace">
+  <wikiDocument name="WebHome">
+    <wikiDocumentLocale>
+      <p>
+        <parameters>
+          <entry>
+            <string>creation_author</string>
+            <string>XWiki.47826731</string>
+          </entry>
+          <entry>
+            <string>creation_date</string>
+            <date>2012-08-21 15:37:47.0 UTC</date>
+          </entry>
+          <entry>
+            <string>lastrevision</string>
+            <string>1</string>
+          </entry>
+        </parameters>
+      </p>
+      <wikiDocumentRevision revision="1">
+        <p>
+          <parameters>
+            <entry>
+              <string>revision_author</string>
+              <string>XWiki.47826731</string>
+            </entry>
+            <entry>
+              <string>revision_date</string>
+              <date>2016-10-11 14:47:37.0 UTC</date>
+            </entry>
+            <entry>
+              <string>revision_comment</string>
+              <string></string>
+            </entry>
+            <entry>
+              <string>title</string>
+              <string>My Space</string>
+            </entry>
+            <entry>
+              <string>content</string>
+              <string>{{locationSearch reference="OutsideSpace.DEMO" showExcerpts="true" width="100%"/}}
+
+{{unsupported-macro-which-converts-to-bridge spaceKey="OutsideSpace.DEMO" size="large" additional="none" confluence_fakeparam="yes" atlassian-macro-output-type="INLINE"/}}
+
+{{documentTree root="document:WebHome"/}}
+
+{{view-file origpleasecollide="fromConverter" randomParam="42"/}}
+
+{{convertedtoblock pleasecrash="yes" pleasecollide="yes" confluence_pleasecollide="fromconfluence" confluence_whyprefixed="dontknow" atlassian-macro-output-type="INLINE"/}}</string>
+            </entry>
+            <entry>
+              <string>syntax</string>
+              <org.xwiki.rendering.syntax.Syntax>
+                <type>
+                  <name>XWiki</name>
+                  <id>xwiki</id>
+                  <variants class="empty-list"/>
+                </type>
+                <version>2.1</version>
+              </org.xwiki.rendering.syntax.Syntax>
+            </entry>
+          </parameters>
+        </p>
+      </wikiDocumentRevision>
+    </wikiDocumentLocale>
+  </wikiDocument>
+</wikiSpace>
+.#------------------------------------------------------------------------------
+.input|confluence+xml
+.configuration.source=keptparams
+.configuration.storeConfluenceDetailsEnabled=false
+.configuration.keptMacroParameterMode=NONE
+.#------------------------------------------------------------------------------

--- a/confluence-xml/src/test/resources/confluencexml/keptparamsunhandled.test
+++ b/confluence-xml/src/test/resources/confluencexml/keptparamsunhandled.test
@@ -1,0 +1,76 @@
+.#------------------------------------------------------------------------------
+.expect|filter+xml
+.#------------------------------------------------------------------------------
+<wikiSpace name="MySpace">
+  <wikiDocument name="WebHome">
+    <wikiDocumentLocale>
+      <p>
+        <parameters>
+          <entry>
+            <string>creation_author</string>
+            <string>XWiki.47826731</string>
+          </entry>
+          <entry>
+            <string>creation_date</string>
+            <date>2012-08-21 15:37:47.0 UTC</date>
+          </entry>
+          <entry>
+            <string>lastrevision</string>
+            <string>1</string>
+          </entry>
+        </parameters>
+      </p>
+      <wikiDocumentRevision revision="1">
+        <p>
+          <parameters>
+            <entry>
+              <string>revision_author</string>
+              <string>XWiki.47826731</string>
+            </entry>
+            <entry>
+              <string>revision_date</string>
+              <date>2016-10-11 14:47:37.0 UTC</date>
+            </entry>
+            <entry>
+              <string>revision_comment</string>
+              <string></string>
+            </entry>
+            <entry>
+              <string>title</string>
+              <string>My Space</string>
+            </entry>
+            <entry>
+              <string>content</string>
+              <string>{{locationSearch atlassian-macro-output-type="INLINE" reference="OutsideSpace.DEMO" showExcerpts="true" width="100%"/}}
+
+{{unsupported-macro-which-converts-to-bridge spaceKey="OutsideSpace.DEMO" size="large" additional="none" confluence_fakeparam="yes" atlassian-macro-output-type="INLINE"/}}
+
+{{documentTree confluence_expandCollapseAll="true" confluence_searchBox="true" confluence_startDepth="3" root="document:WebHome"/}}
+
+{{view-file atlassian-macro-output-type="INLINE" origpleasecollide="fromConverter" randomParam="42"/}}
+
+{{convertedtoblock pleasecrash="yes" pleasecollide="yes" confluence_pleasecollide="fromconfluence" confluence_whyprefixed="dontknow" atlassian-macro-output-type="INLINE"/}}</string>
+            </entry>
+            <entry>
+              <string>syntax</string>
+              <org.xwiki.rendering.syntax.Syntax>
+                <type>
+                  <name>XWiki</name>
+                  <id>xwiki</id>
+                  <variants class="empty-list"/>
+                </type>
+                <version>2.1</version>
+              </org.xwiki.rendering.syntax.Syntax>
+            </entry>
+          </parameters>
+        </p>
+      </wikiDocumentRevision>
+    </wikiDocumentLocale>
+  </wikiDocument>
+</wikiSpace>
+.#------------------------------------------------------------------------------
+.input|confluence+xml
+.configuration.source=keptparams
+.configuration.storeConfluenceDetailsEnabled=false
+.configuration.keptMacroParameterMode=UNHANDLED
+.#------------------------------------------------------------------------------


### PR DESCRIPTION
This is for keeping original Confluence parameters.

@Josue-T adding you as a reviewer for double checking if you see something wrong, and to validate it'll play well with the macro converters you wrote, or if you see something I overlooked