### PR TITLE
Switching to org.apache.commons.lang3.StringUtils

### DIFF
--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/input/ConfluenceXMLPackage.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/input/ConfluenceXMLPackage.java
@@ -68,7 +68,7 @@ import org.apache.commons.io.FileSystem;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.input.CloseShieldInputStream;
 import org.apache.commons.io.input.CountingInputStream;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.slf4j.Logger;

--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/JiraMacroConverter.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/JiraMacroConverter.java
@@ -24,7 +24,7 @@ import java.util.Map;
 
 import javax.inject.Singleton;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.xwiki.component.annotation.Component;
 
 /**


### PR DESCRIPTION
Switching usage of _org.apache.commons.lang.StringUtils_ to _org.apache.commons.lang3.StringUtils_ in **confluence-xml** as commons-lang is no longer supported as a dependency by xwiki-commons causing Confluence XML Extension to crash. 