### PR TITLE
CONFLUENCE-490: LivesearchMacroConverter: Convert space key to doc ref

### DIFF
--- a/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/LivesearchMacroConverter.java
+++ b/confluence-xml/src/main/java/org/xwiki/contrib/confluence/filter/internal/macros/LivesearchMacroConverter.java
@@ -86,7 +86,8 @@ public class LivesearchMacroConverter extends AbstractMacroConverter
         Map<String, String> parameters = new HashMap<>();
 
         if (space != null && !space.isEmpty()) {
-            parameters.put("reference", space);
+            //Append .WebHome to Confluence space key to create a valid XWiki reference
+            parameters.put("reference", converter.convertSpaceReference(space, true));
         }
 
         boolean excerpt = confluenceParameters.getOrDefault("additional", "").contains("none");


### PR DESCRIPTION
Convert the Confluence space key to a document reference with appended ".WebHome", otherwise the location restriction for the location search macro will not work. 