### PR TITLE
CONFLUENCE-531: Floating image is merged into the next paragraph

### DIFF
--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/ImageTagHandler.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/ImageTagHandler.java
@@ -136,7 +136,6 @@ public class ImageTagHandler extends TagHandler implements ConfluenceTagHandler
 
     private static boolean isInline(TagContext context, IWikiScannerContext scannerContext)
     {
-        scannerContext.isInInlineProperty();
         return scannerContext.isInHeader() || isInParagraph(context) || hasInlineParent(context);
     }
 

--- a/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/ImageTagHandler.java
+++ b/confluence-syntax-xhtml/src/main/java/org/xwiki/contrib/confluence/parser/xhtml/internal/wikimodel/ImageTagHandler.java
@@ -20,10 +20,12 @@
 package org.xwiki.contrib.confluence.parser.xhtml.internal.wikimodel;
 
 import org.xwiki.rendering.wikimodel.WikiParameter;
+import org.xwiki.rendering.wikimodel.impl.IWikiScannerContext;
 import org.xwiki.rendering.wikimodel.xhtml.handler.TagHandler;
 import org.xwiki.rendering.wikimodel.xhtml.impl.TagContext;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Handles images.
@@ -65,6 +67,9 @@ public class ImageTagHandler extends TagHandler implements ConfluenceTagHandler
     );
 
     private static final String AC_CLASS = "ac:class";
+
+    // Parent XHTML tags in which an image is an inline element and must not be wrapped in its own paragraph.
+    private static final Set<String> INLINE_PARENT_TAGS = Set.of("span", "a", "ac:task-body", "li");
 
     /**
      * Default constructor.
@@ -113,6 +118,36 @@ public class ImageTagHandler extends TagHandler implements ConfluenceTagHandler
         ConfluenceImageWikiReference image =
             (ConfluenceImageWikiReference) context.getTagStack().popStackParameter(CONFLUENCE_CONTAINER);
 
-        context.getScannerContext().onImage(image);
+        // An image is an inline element. Confluence sometimes exports images as loose elements sitting directly
+        // between block elements (not wrapped in a paragraph). In that case WikiModel would open an implicit
+        // paragraph for the image and then merge the following block into it, gluing the image to the next block's
+        // text. To keep such a standalone image on its own line, we wrap it in its own paragraph when it is not
+        // already in an inline context. This mirrors how MacroTagHandler decides whether a macro is inline.
+        IWikiScannerContext scannerContext = context.getScannerContext();
+        boolean standalone = !isInline(context, scannerContext);
+        if (standalone) {
+            scannerContext.beginParagraph();
+        }
+        scannerContext.onImage(image);
+        if (standalone) {
+            scannerContext.endParagraph();
+        }
+    }
+
+    private static boolean isInline(TagContext context, IWikiScannerContext scannerContext)
+    {
+        scannerContext.isInInlineProperty();
+        return scannerContext.isInHeader() || isInParagraph(context) || hasInlineParent(context);
+    }
+
+    private static boolean isInParagraph(TagContext context)
+    {
+        return context.getTagStack().getStackParameter(CONFLUENCE_IN_PARAGRAPH) != null;
+    }
+
+    private static boolean hasInlineParent(TagContext context)
+    {
+        TagContext parent = context.getParent();
+        return parent != null && INLINE_PARENT_TAGS.contains(parent.getName());
     }
 }

--- a/confluence-xml/src/test/resources/confluencexml/images.test
+++ b/confluence-xml/src/test/resources/confluencexml/images.test
@@ -24,7 +24,13 @@
 
 [[some caption3>>image:attach:rock.jpg||custom-width="true" original-height="1200" data-xwiki-image-style-alignment="start" alt="some alt text" width="50" data-xwiki-image-style-text-wrap="true" original-width="1200"]]
 
-[[some caption4>>image:attach:rock.jpg||custom-width="true" original-height="1200" data-xwiki-image-style-alignment="end" alt="some alt text" width="50" data-xwiki-image-style-text-wrap="true" original-width="1200"]]</string>
+[[some caption4>>image:attach:rock.jpg||custom-width="true" original-height="1200" data-xwiki-image-style-alignment="end" alt="some alt text" width="50" data-xwiki-image-style-text-wrap="true" original-width="1200"]]
+
+This is some test to make sure that some images that are not wrapped in a paragraph, but are block level are actually displayed correctly
+
+[[image:attach:rock.jpg||original-height="397" data-xwiki-image-style-alignment="start" width="476" original-width="480"]]
+
+Another paragraph</string>
             </entry>
             <entry>
               <string>syntax</string>

--- a/confluence-xml/src/test/resources/confluencexml/images/entities.xml
+++ b/confluence-xml/src/test/resources/confluencexml/images/entities.xml
@@ -66,6 +66,11 @@
             </ac:caption>
           </ac:image>
         </p>
+        <p> This is some test to make sure that some images that are not wrapped in a paragraph, but are block level are actually displayed correctly </p>
+        <ac:image ac:align="left" ac:layout="align-start" ac:original-height="397" ac:original-width="480" ac:width="476">
+          <ri:attachment ri:filename="rock.jpg" ri:version-at-save="1" />
+         </ac:image>
+        <p>Another paragraph</p>
       ]]>
     </property>
     <property name="content" class="Page" package="com.atlassian.confluence.pages">

--- a/confluence-xml/src/test/resources/confluencexml/imagessub.test
+++ b/confluence-xml/src/test/resources/confluencexml/imagessub.test
@@ -25,7 +25,13 @@
 
 [[some caption3>>image:attach:rock.jpg||custom-width="true" original-height="1200" data-xwiki-image-style-alignment="start" alt="some alt text" width="50" data-xwiki-image-style-text-wrap="true" original-width="1200"]]
 
-[[some caption4>>image:attach:rock.jpg||custom-width="true" original-height="1200" data-xwiki-image-style-alignment="end" alt="some alt text" width="50" data-xwiki-image-style-text-wrap="true" original-width="1200"]]</string>
+[[some caption4>>image:attach:rock.jpg||custom-width="true" original-height="1200" data-xwiki-image-style-alignment="end" alt="some alt text" width="50" data-xwiki-image-style-text-wrap="true" original-width="1200"]]
+
+This is some test to make sure that some images that are not wrapped in a paragraph, but are block level are actually displayed correctly
+
+[[image:attach:rock.jpg||original-height="397" data-xwiki-image-style-alignment="start" width="476" original-width="480"]]
+
+Another paragraph</string>
               </entry>
               <entry>
                 <string>syntax</string>


### PR DESCRIPTION
Fixes https://jira.xwiki.org/browse/CONFLUENCE-531

Confluence sometimes exports images as loose elements sitting directly between block elements (not wrapped in a paragraph). In that case WikiModel would open an implicit paragraph for the image and then merge the following block into it, gluing the image to the next block's  text. To keep such a standalone image on its own line, we wrap it in its own paragraph when it is not  already in an inline context. I've updated the code to mirror how MacroTagHandler decides whether a macro is inline or not.